### PR TITLE
Increase clanLength from 4 to 5

### DIFF
--- a/api/src/config.ts
+++ b/api/src/config.ts
@@ -29,7 +29,7 @@ export const config: ConfigProps = {
   usernameLength: [1, 20],
 
   clanWaitTime: 7 * 24 * 60 * 60 * 1000, // 7 days
-  clanLength: [1, 4],
+  clanLength: [1, 5],
 
   bioLength: [1, 150]
 };


### PR DESCRIPTION
Please consider increasing clanLength from 4 to 5.

There are existing legacy clans such as GRIND with a 5-character tag, and the current limit prevents new members from joining or using the same clan tag. Increasing the limit would help preserve established clans and improve the player experience.