### PR TITLE
Extend the current system heavily without changing the core idea behind swordbattle

### DIFF
--- a/REVAMP.md
+++ b/REVAMP.md
@@ -20,6 +20,12 @@ This branch deliberately changes gameplay and server behavior without modifying 
 - Health rejects negative, non-finite, post-death, and overkill mutations.
 - The server package now has a Node-native automated test suite covering the new systems.
 
+## Performance observability
+
+- `/serverinfo` reports cumulative tick timing by phase, packet-size totals grouped by full sync/delta/control traffic, dropped packet count, one-second event-loop delay percentiles, and process memory usage.
+- `npm run bench` runs seeded collision and protocol snapshot benchmarks. Each benchmark validates a deterministic checksum before reporting timings, so performance comparisons also catch behavior drift.
+- Spectator full sync no longer duplicates static map objects in both `mapData.staticObjects` and `entities`; player full sync remains unchanged.
+
 ## Protected surfaces
 
 The revamp does not modify:

--- a/REVAMP.md
+++ b/REVAMP.md
@@ -1,0 +1,32 @@
+# LordHank2 Revamp
+
+This branch deliberately changes gameplay and server behavior without modifying the existing visual language, world map, or shop.
+
+## Gameplay additions
+
+- **Double-tap dash:** double-tap a movement key outside the safe zone for a short collision-phasing burst. Taking player damage interrupts it, and a cooldown prevents spam.
+- **Kill streaks and bounties:** players on streaks build a server-calculated bounty. Eliminating them awards bonus coins and a small health recovery.
+- **Assists:** recent contributors who dealt at least 12% of the victim's maximum health receive assist credit and a contribution-scaled coin award.
+- **Revenge rewards:** eliminating the player who last eliminated you grants a modest, capped coin bonus.
+- **Anti-farming:** repeatedly eliminating the same identity inside two minutes sharply reduces all extra combat rewards, reaching zero on the fourth rapid repeat.
+- **Combat commands:** `/help`, `/stats`, `/dash`, `/bounty`, and `/players` expose the new systems through the existing chat channel.
+
+## Reliability and abuse resistance
+
+- Input packets are capped and unknown input IDs are ignored.
+- Angles are normalized, including a valid zero angle.
+- Mouse force is bounded to the strength the movement code actually supports.
+- Chat and command responses have separate server-side cooldowns.
+- Health rejects negative, non-finite, post-death, and overkill mutations.
+- The server package now has a Node-native automated test suite covering the new systems.
+
+## Protected surfaces
+
+The revamp does not modify:
+
+- files in `client/public/assets`
+- client rendering, HUD styling, animation, or sound code
+- `server/src/game/maps`, `server/src/game/biomes`, `server/src/game/entities/mapObjects`, or `server/src/game/GameMap.js`
+- cosmetics data or shop components/services
+
+The existing GPL-3.0 license and attribution remain intact.

--- a/api/src/app.module.ts
+++ b/api/src/app.module.ts
@@ -16,6 +16,7 @@ import { SupportModule } from './support/support.module';
 import { AnnouncementsModule } from './announcements/announcements.module';
 import { BotsModule } from './bots/bots.module';
 import { AuthService } from './auth/auth.service';
+import { ValorModule } from './valor/valor.module';
 
 @Module({
   imports: [
@@ -57,6 +58,7 @@ import { AuthService } from './auth/auth.service';
     SupportModule,
     AnnouncementsModule,
     BotsModule,
+    ValorModule,
   ],
   providers: [
     AuthService,

--- a/api/src/valor/valor-award.entity.ts
+++ b/api/src/valor/valor-award.entity.ts
@@ -1,0 +1,22 @@
+import { Column, CreateDateColumn, Entity, PrimaryColumn } from 'typeorm';
+
+@Entity({ name: 'valor_awards' })
+export class ValorAward {
+  @PrimaryColumn({ name: 'outbreak_id', type: 'varchar', length: 36 })
+  outbreakId: string;
+
+  @PrimaryColumn({ name: 'account_id', type: 'int' })
+  accountId: number;
+
+  @Column({ type: 'int' })
+  crests: number;
+
+  @Column({ name: 'zombie_kills', type: 'int', default: 0 })
+  zombieKills: number;
+
+  @Column({ type: 'boolean', default: false })
+  mvp: boolean;
+
+  @CreateDateColumn({ name: 'created_at' })
+  createdAt: Date;
+}

--- a/api/src/valor/valor-profile.entity.ts
+++ b/api/src/valor/valor-profile.entity.ts
@@ -1,0 +1,22 @@
+import { Column, Entity, PrimaryColumn, UpdateDateColumn } from 'typeorm';
+
+@Entity({ name: 'valor_profiles' })
+export class ValorProfile {
+  @PrimaryColumn({ name: 'account_id', type: 'int' })
+  accountId: number;
+
+  @Column({ type: 'int', default: 0 })
+  crests: number;
+
+  @Column({ name: 'outbreaks_cleared', type: 'int', default: 0 })
+  outbreaksCleared: number;
+
+  @Column({ name: 'zombie_kills', type: 'int', default: 0 })
+  zombieKills: number;
+
+  @Column({ name: 'mvp_count', type: 'int', default: 0 })
+  mvpCount: number;
+
+  @UpdateDateColumn({ name: 'updated_at' })
+  updatedAt: Date;
+}

--- a/api/src/valor/valor.controller.ts
+++ b/api/src/valor/valor.controller.ts
@@ -1,0 +1,24 @@
+import { Body, Controller, Get, Param, Post, Query, UseGuards } from '@nestjs/common';
+import { ServerGuard } from '../auth/guards/server.guard';
+import { ValorService } from './valor.service';
+
+@Controller('valor')
+@UseGuards(ServerGuard)
+export class ValorController {
+  constructor(private readonly valor: ValorService) {}
+
+  @Post('award')
+  async award(@Body() body: any) {
+    return { profiles: await this.valor.awardBatch(body?.outbreakId, body?.awards) };
+  }
+
+  @Get('profile/:accountId')
+  profile(@Param('accountId') rawAccountId: string) {
+    return this.valor.profile(Number(rawAccountId));
+  }
+
+  @Get('top')
+  async top(@Query('limit') rawLimit: string) {
+    return { profiles: await this.valor.top(Number(rawLimit) || 10) };
+  }
+}

--- a/api/src/valor/valor.module.ts
+++ b/api/src/valor/valor.module.ts
@@ -1,0 +1,14 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { ValorAward } from './valor-award.entity';
+import { ValorProfile } from './valor-profile.entity';
+import { ValorController } from './valor.controller';
+import { ValorService } from './valor.service';
+
+@Module({
+  imports: [TypeOrmModule.forFeature([ValorProfile, ValorAward])],
+  controllers: [ValorController],
+  providers: [ValorService],
+  exports: [ValorService],
+})
+export class ValorModule {}

--- a/api/src/valor/valor.service.spec.ts
+++ b/api/src/valor/valor.service.spec.ts
@@ -1,0 +1,40 @@
+import { ValorAward } from './valor-award.entity';
+import { ValorProfile } from './valor-profile.entity';
+import { ValorService } from './valor.service';
+
+describe('ValorService', () => {
+  it('applies an outbreak/account award once and never decreases Crests', async () => {
+    const profiles = new Map<number, any>();
+    const ledger = new Map<string, any>();
+    const repository: any = {
+      create: (data: any) => ({ ...data }),
+      findOne: async ({ where }: any) => profiles.get(where.accountId) || null,
+    };
+    const manager: any = {
+      findOne: async (entity: any, { where }: any) => entity === ValorAward
+        ? ledger.get(`${where.outbreakId}:${where.accountId}`) || null
+        : profiles.get(where.accountId) || null,
+      insert: async (_entity: any, data: any) => {
+        const key = `${data.outbreakId}:${data.accountId}`;
+        if (ledger.has(key)) throw new Error('duplicate');
+        ledger.set(key, { ...data });
+      },
+      create: (_entity: any, data: any) => ({ ...data }),
+      save: async (_entity: any, data: any) => {
+        profiles.set(data.accountId, { ...data });
+        return data;
+      },
+    };
+    const dataSource: any = { transaction: async (_level: string, fn: any) => fn(manager) };
+    const service = new ValorService(dataSource, repository);
+    const outbreakId = '11111111-1111-4111-8111-111111111111';
+    const awards = [{ accountId: 5, crests: 6, zombieKills: 3, mvp: true }];
+
+    await service.awardBatch(outbreakId, awards);
+    await service.awardBatch(outbreakId, awards);
+
+    expect(await service.profile(5)).toMatchObject({
+      accountId: 5, crests: 6, outbreaksCleared: 1, zombieKills: 3, mvpCount: 1,
+    });
+  });
+});

--- a/api/src/valor/valor.service.ts
+++ b/api/src/valor/valor.service.ts
@@ -1,0 +1,87 @@
+import { BadRequestException, Injectable } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { DataSource, Repository } from 'typeorm';
+import { ValorAward } from './valor-award.entity';
+import { ValorProfile } from './valor-profile.entity';
+
+export interface ValorAwardInput {
+  accountId: number;
+  crests: number;
+  zombieKills?: number;
+  mvp?: boolean;
+}
+
+@Injectable()
+export class ValorService {
+  constructor(
+    private readonly dataSource: DataSource,
+    @InjectRepository(ValorProfile) private readonly profiles: Repository<ValorProfile>,
+  ) {}
+
+  private blank(accountId: number): ValorProfile {
+    return this.profiles.create({
+      accountId,
+      crests: 0,
+      outbreaksCleared: 0,
+      zombieKills: 0,
+      mvpCount: 0,
+    });
+  }
+
+  async profile(accountId: number) {
+    if (!Number.isInteger(accountId) || accountId <= 0) throw new BadRequestException('Invalid account ID');
+    return (await this.profiles.findOne({ where: { accountId } })) || this.blank(accountId);
+  }
+
+  async top(limit = 10) {
+    const take = Math.max(1, Math.min(10, Math.floor(Number(limit)) || 10));
+    const rows = await this.profiles.createQueryBuilder('valor')
+      .leftJoin('accounts', 'account', 'account.id = valor.account_id')
+      .select('valor.account_id', 'accountId')
+      .addSelect('account.username', 'username')
+      .addSelect('valor.crests', 'crests')
+      .addSelect('valor.outbreaks_cleared', 'outbreaksCleared')
+      .addSelect('valor.zombie_kills', 'zombieKills')
+      .addSelect('valor.mvp_count', 'mvpCount')
+      .orderBy('valor.crests', 'DESC')
+      .addOrderBy('valor.mvp_count', 'DESC')
+      .addOrderBy('valor.account_id', 'ASC')
+      .limit(take)
+      .getRawMany();
+    return rows.map(row => ({
+      accountId: Number(row.accountId), username: row.username || `Account ${row.accountId}`,
+      crests: Number(row.crests), outbreaksCleared: Number(row.outbreaksCleared),
+      zombieKills: Number(row.zombieKills), mvpCount: Number(row.mvpCount),
+    }));
+  }
+
+  async awardBatch(outbreakId: string, inputs: ValorAwardInput[]) {
+    if (!/^[0-9a-f-]{36}$/i.test(String(outbreakId || ''))) throw new BadRequestException('Invalid outbreak ID');
+    if (!Array.isArray(inputs) || inputs.length === 0 || inputs.length > 100) throw new BadRequestException('Invalid awards');
+    const seen = new Set<number>();
+    const awards = inputs.map(input => {
+      const accountId = Math.floor(Number(input.accountId));
+      const crests = Math.floor(Number(input.crests));
+      const zombieKills = Math.max(0, Math.floor(Number(input.zombieKills) || 0));
+      if (accountId <= 0 || crests <= 0 || crests > 6 || seen.has(accountId)) throw new BadRequestException('Invalid award entry');
+      seen.add(accountId);
+      return { accountId, crests, zombieKills, mvp: !!input.mvp };
+    });
+
+    await this.dataSource.transaction('SERIALIZABLE', async manager => {
+      for (const award of awards) {
+        const exists = await manager.findOne(ValorAward, { where: { outbreakId, accountId: award.accountId } });
+        if (exists) continue;
+        await manager.insert(ValorAward, { outbreakId, ...award });
+        let profile = await manager.findOne(ValorProfile, { where: { accountId: award.accountId } });
+        if (!profile) profile = manager.create(ValorProfile, this.blank(award.accountId));
+        profile.crests += award.crests;
+        profile.outbreaksCleared += 1;
+        profile.zombieKills += award.zombieKills;
+        if (award.mvp) profile.mvpCount += 1;
+        await manager.save(ValorProfile, profile);
+      }
+    });
+    return Promise.all(awards.map(award => this.profile(award.accountId)));
+  }
+}

--- a/client/public/assets/game/valor-crest.svg
+++ b/client/public/assets/game/valor-crest.svg
@@ -1,0 +1,29 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="256" height="256" viewBox="0 0 256 256">
+  <defs>
+    <linearGradient id="gold" x1="0" y1="0" x2="1" y2="1"><stop stop-color="#fff5ad"/><stop offset=".22" stop-color="#f5c54a"/><stop offset=".58" stop-color="#9c5f11"/><stop offset=".78" stop-color="#f8da70"/><stop offset="1" stop-color="#80500e"/></linearGradient>
+    <linearGradient id="silver" x1="0" y1="0" x2="1" y2="1"><stop stop-color="#fff"/><stop offset=".35" stop-color="#92b7cf"/><stop offset=".62" stop-color="#f0fbff"/><stop offset="1" stop-color="#526a82"/></linearGradient>
+    <radialGradient id="blue" cx="34%" cy="25%" r="80%"><stop stop-color="#72edff"/><stop offset=".28" stop-color="#168fdc"/><stop offset=".7" stop-color="#123b99"/><stop offset="1" stop-color="#081a55"/></radialGradient>
+    <linearGradient id="blade" x1="0" y1="0" x2="1" y2="0"><stop stop-color="#698ba7"/><stop offset=".42" stop-color="#fff"/><stop offset=".62" stop-color="#aeeeff"/><stop offset="1" stop-color="#425b76"/></linearGradient>
+    <filter id="shadow" x="-30%" y="-30%" width="160%" height="170%"><feDropShadow dx="0" dy="6" stdDeviation="5" flood-color="#02091d" flood-opacity=".8"/></filter>
+  </defs>
+  <g filter="url(#shadow)" stroke="#07152c" stroke-linejoin="round">
+    <path d="M128 13 226 48v64c0 65-39 109-98 132-59-23-98-67-98-132V48z" fill="url(#gold)" stroke-width="12"/>
+    <path d="M128 29 208 58v53c0 53-30 91-80 113-50-22-80-60-80-113V58z" fill="url(#silver)" stroke-width="5"/>
+    <path d="M128 40 196 65v45c0 46-25 79-68 99-43-20-68-53-68-99V65z" fill="url(#blue)" stroke-width="7"/>
+    <path d="M75 76c32-25 73-27 106-6-28 2-57 14-78 37-13 14-21 31-26 50-9-27-10-56-2-81z" fill="#baf8ff" opacity=".25" stroke="none"/>
+    <g stroke-width="6">
+      <path d="m71 55 28 19 70 108-18 12L85 82z" fill="url(#blade)"/>
+      <path d="m185 54-27 20-69 109 18 11 65-111z" fill="url(#blade)"/>
+      <path d="m79 159 35 23-8 14-36-23z" fill="url(#gold)"/>
+      <path d="m177 159-35 23 8 14 36-23z" fill="url(#gold)"/>
+      <path d="m72 174 19 13-13 27-17-11zM184 174l-19 13 13 27 17-11z" fill="#775018"/>
+      <path d="m61 203 18 12-15 13-13-9zM195 203l-18 12 15 13 13-9z" fill="url(#gold)"/>
+    </g>
+    <path d="M128 81 140 112 174 114 147 135 155 168 128 149 101 168 109 135 82 114 116 112z" fill="#71efff" stroke="#dffcff" stroke-width="5"/>
+    <path d="m128 93 6 25 25 2-20 14 6 24-17-14z" fill="#fff" opacity=".52" stroke="none"/>
+  </g>
+  <g fill="#fff">
+    <path d="m190 35 4 12 12 4-12 4-4 12-4-12-12-4 12-4z"/>
+    <circle cx="174" cy="31" r="4"/><circle cx="207" cy="72" r="3"/>
+  </g>
+</svg>

--- a/client/src/game/Types.ts
+++ b/client/src/game/Types.ts
@@ -45,6 +45,7 @@ export enum EntityTypes {
   SandBall = 42,
   Ore = 43,
   AmbientShrub = 44,
+  Zombie = 45,
 }
 
 export enum FlagTypes {

--- a/client/src/game/entities/Player.ts
+++ b/client/src/game/entities/Player.ts
@@ -70,7 +70,7 @@ class Player extends BaseEntity {
     'swordSwingAngle', 'swordSwingProgress', 'swordSwingDuration', 'swordSwingArc', 'swordFlying', 'swordFlyingCooldown', 'swordBoomerangReturning',
     'swordRaising', 'swordDecreasing', 'offhandRaising', 'offhandDecreasing',
     'activeSelection', 'abilityCharges',
-    'viewportZoom', 'chatMessage', 'skin', 'skinName', 'account', 'wideSwing',
+    'viewportZoom', 'chatMessage', 'skin', 'skinName', 'account', 'wideSwing', 'valorCrests',
     'cardOffers', 'chosenCards', 'choosingCard', 'cardTimer', 'cardPickNumber', 'availableUpgrades',
     'rerollsAvailable', 'pendingPicks', 'skipResults', 'isTutorial',
   ];
@@ -139,6 +139,9 @@ class Player extends BaseEntity {
   private radarPulseElapsed: number = -1;
   private radarSweepAngle: number = 0;
   private _lastSilenced: boolean = false;
+  protected usesDedicatedEventTextures: boolean = false;
+  valorCrestContainer?: Phaser.GameObjects.Container;
+  valorCrestCount?: Phaser.GameObjects.Text;
 
   get survivalTime() {
     return (Date.now() - this.survivalStarted) / 1000;
@@ -245,6 +248,15 @@ class Player extends BaseEntity {
     this.container.addChildAt(nameTag, 6);
     if (clanText) this.container.add(clanText);
 
+    const crestIcon = this.game.add.image(-7, 0, 'valorCrest').setDisplaySize(22, 22).setOrigin(1, 0.5);
+    this.valorCrestCount = this.game.add.text(-2, 0, '', {
+      fontFamily: "'Saira', sans-serif", fontSize: '18px', fontStyle: '700',
+      color: '#dffcff', stroke: '#07152c', strokeThickness: 3,
+    }).setOrigin(0, 0.5);
+    this.valorCrestContainer = this.game.add.container(0, nameY + 38, [crestIcon, this.valorCrestCount]);
+    this.valorCrestContainer.setVisible(false);
+    this.container.add(this.valorCrestContainer);
+
     if (ogex) {
       try {
         const clearSparkle = () => {
@@ -284,7 +296,7 @@ class Player extends BaseEntity {
       }
     }
 
-    if (!Settings.unloadSkins) {
+    if (!Settings.unloadSkins && !this.usesDedicatedEventTextures) {
       if (Settings.loadskins) {
           this.loadSkin(this.skin).then(() => {
           const skinBase = skins.player.name;
@@ -1428,6 +1440,9 @@ class Player extends BaseEntity {
     }
 
     this.updateCardSummary();
+    const crests = Math.max(0, Math.floor(Number(this.valorCrests) || 0));
+    this.valorCrestContainer?.setVisible(crests > 0);
+    if (crests > 0 && this.valorCrestCount?.text !== String(crests)) this.valorCrestCount?.setText(String(crests));
 
     const ups = ((this as any).currentUpgrades || []);
     const throwHidesSword = ups.includes(UpgradeTypes.Battleswords) || ups.includes(UpgradeTypes.Kunais);

--- a/client/src/game/entities/Zombie.ts
+++ b/client/src/game/entities/Zombie.ts
@@ -1,0 +1,22 @@
+import Player from './Player';
+
+const textures: Record<number, { body: string; sword: string }> = {
+  1: { body: 'realZombieBody', sword: 'realZombieSword' },
+  2: { body: 'nightlurkerBody', sword: 'nightlurkerSword' },
+  3: { body: 'bonedragonBody', sword: 'bonedragonSword' },
+};
+
+export default class Zombie extends Player {
+  protected usesDedicatedEventTextures = true;
+
+  createSprite() {
+    const container = super.createSprite();
+    const texture = textures[this.skin] || textures[1];
+    this.bodyScale = 1;
+    this.body.setTexture(texture.body);
+    this.shadow.setTexture(this.createShadowTexture(texture.body));
+    this.sword.setTexture(texture.sword);
+    this.swordShadow.setTexture(this.createShadowTexture(texture.sword));
+    return container;
+  }
+}

--- a/client/src/game/entities/index.ts
+++ b/client/src/game/entities/index.ts
@@ -42,6 +42,7 @@ import AngryFishMob from './mobs/AngryFish';
 import IceSpiritMob from './mobs/IceSpirit';
 import CaptureZone from './CaptureZone';
 import ThrownSword from './ThrownSword';
+import Zombie from './Zombie';
 
 export const EntityDepth: Record<any, number> = {
   [EntityTypes.CaptureZone]: 0.5,
@@ -68,6 +69,7 @@ export const EntityDepth: Record<any, number> = {
   [EntityTypes.IceSpirit]: 11,
 
   [EntityTypes.Player]: 20,
+  [EntityTypes.Zombie]: 20,
   [EntityTypes.Sword]: 21,
   [EntityTypes.Fireball]: 22,
   [EntityTypes.Boulder]: 22,
@@ -96,6 +98,7 @@ export const EntityDepth: Record<any, number> = {
 export const GetEntityClass = (type: EntityTypes): typeof BaseEntity => {
   switch (type) {
     case EntityTypes.Player: return Player;
+    case EntityTypes.Zombie: return Zombie;
     case EntityTypes.Coin: return Coin;
     case EntityTypes.Token: return Token;
     case EntityTypes.House1: return House1;

--- a/client/src/game/network/Protocol.ts
+++ b/client/src/game/network/Protocol.ts
@@ -1512,6 +1512,7 @@ export interface Entity {
   offhandDecreasing?: boolean;
   activeSelection?: number;
   abilityCharges?: number;
+  valorCrests?: number;
   cardOffers?: number[];
   chosenCards?: number[];
   choosingCard?: boolean;
@@ -2032,6 +2033,13 @@ function _encodeEntity(message: Entity, bb: ByteBuffer): void {
   if ($abilityCharges !== undefined) {
     writeVarint32(bb, 552);
     writeVarint64(bb, intToLong($abilityCharges));
+  }
+
+  // optional int32 valorCrests = 70;
+  let $valorCrests = message.valorCrests;
+  if ($valorCrests !== undefined) {
+    writeVarint32(bb, 560);
+    writeVarint64(bb, intToLong($valorCrests));
   }
 
 }
@@ -2570,6 +2578,12 @@ function _decodeEntity(bb: ByteBuffer): Entity {
       // optional int32 abilityCharges = 69;
       case 69: {
         message.abilityCharges = readVarint32(bb);
+        break;
+      }
+
+      // optional int32 valorCrests = 70;
+      case 70: {
+        message.valorCrests = readVarint32(bb);
         break;
       }
 

--- a/client/src/game/network/schema.proto
+++ b/client/src/game/network/schema.proto
@@ -170,4 +170,5 @@ message Entity {
   bool offhandDecreasing = 67;
   int32 activeSelection = 68;
   int32 abilityCharges = 69;
+  int32 valorCrests = 70;
 }

--- a/client/src/game/scenes/Game.ts
+++ b/client/src/game/scenes/Game.ts
@@ -72,6 +72,14 @@ export default class Game extends Phaser.Scene {
     // Signal that asset loading has started
     crazygamesSDK.loadingStart();
 
+    this.load.image('realZombieBody', publicPath + '/assets/game/player/realZombiePlayer.png');
+    this.load.image('realZombieSword', publicPath + '/assets/game/player/realZombieSword.png');
+    this.load.image('nightlurkerBody', publicPath + '/assets/game/player/nightlurkerPlayer.png');
+    this.load.image('nightlurkerSword', publicPath + '/assets/game/player/nightlurkerSword.png');
+    this.load.image('bonedragonBody', publicPath + '/assets/game/player/bonedragonPlayer.png');
+    this.load.image('bonedragonSword', publicPath + '/assets/game/player/bonedragonSword.png');
+    this.load.image('valorCrest', publicPath + '/assets/game/valor-crest.svg');
+
     this.load.image('wrenchIcon', publicPath + '/assets/game/ui/wrench.png');
     this.load.image('closeIcon', publicPath + '/assets/game/ui/close.png');
     this.load.image('rockTile', publicPath + '/assets/game/tiles/rock.png');

--- a/server/bench/collision.bench.js
+++ b/server/bench/collision.bench.js
@@ -1,0 +1,135 @@
+const { performance } = require('node:perf_hooks');
+const QuadTree = require('../src/game/components/Quadtree');
+const { rectangleRectangle } = require('../src/game/collisions');
+
+const DEFAULT_SIGNATURE = '28329:6120:3015404203';
+
+function createRandom(seed) {
+  let state = seed >>> 0;
+  return () => {
+    state += 0x6D2B79F5;
+    let value = state;
+    value = Math.imul(value ^ (value >>> 15), value | 1);
+    value ^= value + Math.imul(value ^ (value >>> 7), value | 61);
+    return ((value ^ (value >>> 14)) >>> 0) / 4294967296;
+  };
+}
+
+function hashInteger(hash, value) {
+  hash ^= value >>> 0;
+  return Math.imul(hash, 16777619) >>> 0;
+}
+
+function createCollisionFixture(options = {}) {
+  const entityCount = options.entityCount || 4000;
+  const queryCount = options.queryCount || 2000;
+  const worldSize = options.worldSize || 24000;
+  const random = createRandom(options.seed || 0x5A0BDA7A);
+  const rectangles = [];
+  const queries = [];
+
+  for (let id = 1; id <= entityCount; id++) {
+    const width = 16 + Math.floor(random() * 160);
+    const height = 16 + Math.floor(random() * 160);
+    rectangles.push({
+      x: Math.floor(random() * (worldSize - width)),
+      y: Math.floor(random() * (worldSize - height)),
+      width,
+      height,
+      entity: { id },
+    });
+  }
+
+  for (let index = 0; index < queryCount; index++) {
+    const width = 120 + Math.floor(random() * 900);
+    const height = 120 + Math.floor(random() * 900);
+    queries.push({
+      x: Math.floor(random() * (worldSize - width)),
+      y: Math.floor(random() * (worldSize - height)),
+      width,
+      height,
+    });
+  }
+
+  return { worldSize, rectangles, queries };
+}
+
+function executeCollisionPass(fixture) {
+  const tree = new QuadTree({
+    x: 0,
+    y: 0,
+    width: fixture.worldSize,
+    height: fixture.worldSize,
+  }, 10, 5);
+
+  const buildStartedAt = performance.now();
+  for (const rectangle of fixture.rectangles) tree.insert(rectangle);
+  const buildMs = performance.now() - buildStartedAt;
+
+  let candidateCount = 0;
+  let exactHitCount = 0;
+  let checksum = 2166136261;
+  const queryStartedAt = performance.now();
+  for (let queryIndex = 0; queryIndex < fixture.queries.length; queryIndex++) {
+    const query = fixture.queries[queryIndex];
+    const candidates = tree.get(query);
+    candidateCount += candidates.length;
+    checksum = hashInteger(checksum, queryIndex);
+    for (const candidate of candidates) {
+      if (!rectangleRectangle(candidate, query)) continue;
+      exactHitCount += 1;
+      checksum = hashInteger(checksum, candidate.entity.id);
+    }
+  }
+  const queryMs = performance.now() - queryStartedAt;
+
+  return { buildMs, queryMs, candidateCount, exactHitCount, checksum };
+}
+
+function runCollisionBenchmark(options = {}) {
+  const iterations = options.iterations || 5;
+  const fixture = createCollisionFixture(options);
+  const samples = [];
+  let expected = null;
+
+  for (let iteration = 0; iteration < iterations; iteration++) {
+    const sample = executeCollisionPass(fixture);
+    const deterministicSignature = `${sample.candidateCount}:${sample.exactHitCount}:${sample.checksum}`;
+    if (expected === null) expected = deterministicSignature;
+    if (deterministicSignature !== expected) {
+      throw new Error(`Collision benchmark became nondeterministic: ${deterministicSignature} != ${expected}`);
+    }
+    samples.push(sample);
+  }
+
+  const average = (key) => samples.reduce((sum, sample) => sum + sample[key], 0) / samples.length;
+  const usesDefaultFixture = options.seed === undefined
+    && options.entityCount === undefined
+    && options.queryCount === undefined
+    && options.worldSize === undefined;
+  if (usesDefaultFixture && expected !== DEFAULT_SIGNATURE) {
+    throw new Error(`Collision behavior drifted: ${expected} != ${DEFAULT_SIGNATURE}`);
+  }
+  return {
+    benchmark: 'collision',
+    seed: options.seed || 0x5A0BDA7A,
+    iterations,
+    entityCount: fixture.rectangles.length,
+    queryCount: fixture.queries.length,
+    buildMeanMs: Number(average('buildMs').toFixed(3)),
+    queryMeanMs: Number(average('queryMs').toFixed(3)),
+    candidateCount: samples[0].candidateCount,
+    exactHitCount: samples[0].exactHitCount,
+    checksum: samples[0].checksum,
+  };
+}
+
+if (require.main === module) {
+  console.log(JSON.stringify(runCollisionBenchmark(), null, 2));
+}
+
+module.exports = {
+  createCollisionFixture,
+  executeCollisionPass,
+  runCollisionBenchmark,
+};

--- a/server/bench/collision.bench.js
+++ b/server/bench/collision.bench.js
@@ -1,8 +1,10 @@
 const { performance } = require('node:perf_hooks');
 const QuadTree = require('../src/game/components/Quadtree');
+const WorldIndex = require('../src/game/components/WorldIndex');
 const { rectangleRectangle } = require('../src/game/collisions');
 
-const DEFAULT_SIGNATURE = '28329:6120:3015404203';
+const LEGACY_SIGNATURE = '28329:6120:3015404203';
+const WORLD_INDEX_SIGNATURE = '6120:6120:3190863947';
 
 function createRandom(seed) {
   let state = seed >>> 0;
@@ -54,13 +56,16 @@ function createCollisionFixture(options = {}) {
   return { worldSize, rectangles, queries };
 }
 
-function executeCollisionPass(fixture) {
-  const tree = new QuadTree({
+function executeCollisionPass(fixture, implementation = 'worldIndex') {
+  const boundary = {
     x: 0,
     y: 0,
     width: fixture.worldSize,
     height: fixture.worldSize,
-  }, 10, 5);
+  };
+  const tree = implementation === 'legacy'
+    ? new QuadTree(boundary, 10, 5)
+    : new WorldIndex(boundary, 512);
 
   const buildStartedAt = performance.now();
   for (const rectangle of fixture.rectangles) tree.insert(rectangle);
@@ -89,26 +94,41 @@ function executeCollisionPass(fixture) {
 function runCollisionBenchmark(options = {}) {
   const iterations = options.iterations || 5;
   const fixture = createCollisionFixture(options);
-  const samples = [];
-  let expected = null;
-
-  for (let iteration = 0; iteration < iterations; iteration++) {
-    const sample = executeCollisionPass(fixture);
-    const deterministicSignature = `${sample.candidateCount}:${sample.exactHitCount}:${sample.checksum}`;
-    if (expected === null) expected = deterministicSignature;
-    if (deterministicSignature !== expected) {
-      throw new Error(`Collision benchmark became nondeterministic: ${deterministicSignature} != ${expected}`);
+  const runImplementation = (implementation) => {
+    const samples = [];
+    let expected = null;
+    for (let iteration = 0; iteration < iterations; iteration++) {
+      const sample = executeCollisionPass(fixture, implementation);
+      const deterministicSignature = `${sample.candidateCount}:${sample.exactHitCount}:${sample.checksum}`;
+      if (expected === null) expected = deterministicSignature;
+      if (deterministicSignature !== expected) {
+        throw new Error(`${implementation} collision benchmark became nondeterministic`);
+      }
+      samples.push(sample);
     }
-    samples.push(sample);
-  }
+    const average = (key) => samples.reduce((sum, sample) => sum + sample[key], 0) / samples.length;
+    return {
+      signature: expected,
+      buildMeanMs: Number(average('buildMs').toFixed(3)),
+      queryMeanMs: Number(average('queryMs').toFixed(3)),
+      candidateCount: samples[0].candidateCount,
+      exactHitCount: samples[0].exactHitCount,
+      checksum: samples[0].checksum,
+    };
+  };
 
-  const average = (key) => samples.reduce((sum, sample) => sum + sample[key], 0) / samples.length;
+  const legacy = runImplementation('legacy');
+  const worldIndex = runImplementation('worldIndex');
+
   const usesDefaultFixture = options.seed === undefined
     && options.entityCount === undefined
     && options.queryCount === undefined
     && options.worldSize === undefined;
-  if (usesDefaultFixture && expected !== DEFAULT_SIGNATURE) {
-    throw new Error(`Collision behavior drifted: ${expected} != ${DEFAULT_SIGNATURE}`);
+  if (usesDefaultFixture && legacy.signature !== LEGACY_SIGNATURE) {
+    throw new Error(`Legacy collision behavior drifted: ${legacy.signature} != ${LEGACY_SIGNATURE}`);
+  }
+  if (usesDefaultFixture && worldIndex.signature !== WORLD_INDEX_SIGNATURE) {
+    throw new Error(`WorldIndex behavior drifted: ${worldIndex.signature} != ${WORLD_INDEX_SIGNATURE}`);
   }
   return {
     benchmark: 'collision',
@@ -116,11 +136,11 @@ function runCollisionBenchmark(options = {}) {
     iterations,
     entityCount: fixture.rectangles.length,
     queryCount: fixture.queries.length,
-    buildMeanMs: Number(average('buildMs').toFixed(3)),
-    queryMeanMs: Number(average('queryMs').toFixed(3)),
-    candidateCount: samples[0].candidateCount,
-    exactHitCount: samples[0].exactHitCount,
-    checksum: samples[0].checksum,
+    legacy,
+    worldIndex,
+    candidateReductionPercent: Number(
+      ((1 - worldIndex.candidateCount / legacy.candidateCount) * 100).toFixed(2),
+    ),
   };
 }
 

--- a/server/bench/outbreak-soak.bench.js
+++ b/server/bench/outbreak-soak.bench.js
@@ -1,0 +1,77 @@
+const { performance } = require('node:perf_hooks');
+const WorldIndex = require('../src/game/components/WorldIndex');
+const PerformanceMetrics = require('../src/metrics/PerformanceMetrics');
+
+function runOutbreakSoak(options = {}) {
+  const playerCount = options.playerCount || 100;
+  const zombieCount = options.zombieCount || 2000;
+  const tickRate = options.tickRate || 20;
+  const simulatedSeconds = options.simulatedSeconds || 300;
+  const tickCount = tickRate * simulatedSeconds;
+  const worldSize = 35000;
+  const entities = new Map();
+  const positions = [];
+  let seed = 0x51A7C0DE;
+  const random = () => {
+    seed = (Math.imul(seed, 1664525) + 1013904223) >>> 0;
+    return seed / 4294967296;
+  };
+  const addEntity = (id, radius, speed) => {
+    const state = {
+      x: -worldSize / 2 + radius + random() * (worldSize - radius * 2),
+      y: -worldSize / 2 + radius + random() * (worldSize - radius * 2),
+      vx: (random() * 2 - 1) * speed,
+      vy: (random() * 2 - 1) * speed,
+      radius,
+    };
+    positions.push(state);
+    entities.set(id, {
+      id, isStatic: false, removed: false,
+      shape: { get boundary() { return { x: state.x - radius, y: state.y - radius, width: radius * 2, height: radius * 2 }; } },
+    });
+  };
+  for (let i = 0; i < playerCount; i++) addEntity(i + 1, 72, 310);
+  for (let i = 0; i < zombieCount; i++) addEntity(playerCount + i + 1, i % 20 === 19 ? 105 : 66, 250 + (i % 4) * 35);
+
+  const index = new WorldIndex({ x: -worldSize / 2, y: -worldSize / 2, width: worldSize, height: worldSize }, 512);
+  const metrics = new PerformanceMetrics({ systemSampleIntervalMs: 250 });
+  const dt = 1 / tickRate;
+  let checksum = 2166136261;
+  const started = performance.now();
+  for (let tick = 0; tick < tickCount; tick++) {
+    const tickStarted = performance.now();
+    const moveStarted = performance.now();
+    for (let i = 0; i < positions.length; i++) {
+      const p = positions[i];
+      p.x += p.vx * dt;
+      p.y += p.vy * dt;
+      if (p.x < -worldSize / 2 + p.radius || p.x > worldSize / 2 - p.radius) p.vx *= -1;
+      if (p.y < -worldSize / 2 + p.radius || p.y > worldSize / 2 - p.radius) p.vy *= -1;
+    }
+    metrics.recordPhase('entityUpdate', performance.now() - moveStarted);
+    const syncStarted = performance.now();
+    index.sync(entities);
+    metrics.recordPhase('spatialIndexSync', performance.now() - syncStarted);
+
+    if (tick % tickRate === 0) {
+      const queryStarted = performance.now();
+      for (let i = 0; i < playerCount; i++) {
+        const p = positions[i];
+        const visible = index.get({ x: p.x - 1100, y: p.y - 700, width: 2200, height: 1400 });
+        checksum = Math.imul((checksum ^ visible.length ^ i) >>> 0, 16777619) >>> 0;
+        metrics.recordPacket(24 + visible.length * 32, { kind: 'outbreak-soak' });
+      }
+      metrics.recordPhase('snapshotQueries', performance.now() - queryStarted);
+    }
+    metrics.recordTick(performance.now() - tickStarted);
+  }
+  const report = metrics.snapshot();
+  metrics.close();
+  return {
+    benchmark: 'outbreak-soak', playerCount, zombieCount, simulatedSeconds, tickRate,
+    wallTimeMs: Number((performance.now() - started).toFixed(3)), checksum, metrics: report,
+  };
+}
+
+if (require.main === module) console.log(JSON.stringify(runOutbreakSoak(), null, 2));
+module.exports = { runOutbreakSoak };

--- a/server/bench/run.js
+++ b/server/bench/run.js
@@ -1,7 +1,9 @@
 const { runCollisionBenchmark } = require('./collision.bench');
 const { runSnapshotBenchmark } = require('./snapshot.bench');
+const { runOutbreakSoak } = require('./outbreak-soak.bench');
 
 console.log(JSON.stringify({
   collision: runCollisionBenchmark(),
   snapshot: runSnapshotBenchmark(),
+  outbreakSoak: runOutbreakSoak(),
 }, null, 2));

--- a/server/bench/run.js
+++ b/server/bench/run.js
@@ -1,0 +1,7 @@
+const { runCollisionBenchmark } = require('./collision.bench');
+const { runSnapshotBenchmark } = require('./snapshot.bench');
+
+console.log(JSON.stringify({
+  collision: runCollisionBenchmark(),
+  snapshot: runSnapshotBenchmark(),
+}, null, 2));

--- a/server/bench/snapshot.bench.js
+++ b/server/bench/snapshot.bench.js
@@ -1,0 +1,170 @@
+const { performance } = require('node:perf_hooks');
+const Protocol = require('../src/network/protocol/Protocol');
+
+const DEFAULT_FULL_SIGNATURE = '99580:796156384';
+const DEFAULT_DELTA_SIGNATURE = '12779:4104091516';
+
+function createRandom(seed) {
+  let state = seed >>> 0;
+  return () => {
+    state += 0x6D2B79F5;
+    let value = state;
+    value = Math.imul(value ^ (value >>> 15), value | 1);
+    value ^= value + Math.imul(value ^ (value >>> 7), value | 61);
+    return ((value ^ (value >>> 14)) >>> 0) / 4294967296;
+  };
+}
+
+function hashBytes(bytes) {
+  let hash = 2166136261;
+  for (const byte of bytes) {
+    hash ^= byte;
+    hash = Math.imul(hash, 16777619) >>> 0;
+  }
+  return hash;
+}
+
+function createEntity(id, random, staticEntity = false) {
+  const x = Math.floor(random() * 24000);
+  const y = Math.floor(random() * 24000);
+  return {
+    id,
+    type: staticEntity ? 9 : 1,
+    depth: staticEntity ? id % 8 : 0,
+    shapeData: {
+      type: staticEntity ? 2 : 1,
+      x,
+      y,
+      angle: random() * Math.PI * 2,
+      radius: staticEntity ? 0 : 35 + (id % 20),
+      points: staticEntity ? [
+        { x, y },
+        { x: x + 80 + (id % 40), y },
+        { x: x + 80 + (id % 40), y: y + 80 },
+        { x, y: y + 80 },
+      ] : [],
+    },
+    healthPercent: 0.25 + random() * 0.75,
+    angle: random() * Math.PI * 2,
+    size: 100 + (id % 70),
+    name: staticEntity ? '' : `BenchmarkPlayer${id}`,
+    kills: id % 80,
+    level: 1 + (id % 50),
+    coins: id * 7,
+    tokens: id % 11,
+    evolution: id % 6,
+    flags: { 1: id % 2, 2: (id + 1) % 2 },
+    buffs: { 1: { level: id % 5, max: 5, step: 0.2 } },
+    chosenCards: [id % 10, (id + 3) % 10],
+  };
+}
+
+function createSnapshotFixtures(options = {}) {
+  const seed = options.seed || 0x51A7BEEF;
+  const dynamicEntityCount = options.dynamicEntityCount || 600;
+  const staticEntityCount = options.staticEntityCount || 240;
+  const deltaEntityCount = options.deltaEntityCount || 120;
+  const random = createRandom(seed);
+  const entities = {};
+  const staticObjects = [];
+
+  for (let id = 1; id <= dynamicEntityCount; id++) {
+    entities[id] = createEntity(id, random, false);
+  }
+  for (let id = dynamicEntityCount + 1; id <= dynamicEntityCount + staticEntityCount; id++) {
+    staticObjects.push(createEntity(id, random, true));
+  }
+
+  const deltaEntities = {};
+  for (let id = 1; id <= deltaEntityCount; id++) {
+    deltaEntities[id] = id % 17 === 0
+      ? { id, removed: true }
+      : createEntity(id, random, false);
+  }
+
+  return {
+    full: {
+      fullSync: true,
+      selfId: 1,
+      spectator: { x: 12000, y: 12000 },
+      mapData: {
+        x: 0,
+        y: 0,
+        width: 24000,
+        height: 24000,
+        biomes: [],
+        staticObjects,
+      },
+      // Static objects intentionally exist only in mapData, matching spectator sync.
+      entities,
+      globalEntities: {},
+    },
+    delta: {
+      entities: deltaEntities,
+      globalEntities: {},
+    },
+  };
+}
+
+function benchmarkPayload(name, payload, iterations) {
+  let expectedBytes = null;
+  let expectedChecksum = null;
+  const startedAt = performance.now();
+  for (let iteration = 0; iteration < iterations; iteration++) {
+    const packet = Protocol.encode(payload);
+    const checksum = hashBytes(packet);
+    if (expectedBytes === null) {
+      expectedBytes = packet.byteLength;
+      expectedChecksum = checksum;
+    } else if (packet.byteLength !== expectedBytes || checksum !== expectedChecksum) {
+      throw new Error(`${name} snapshot encoding became nondeterministic`);
+    }
+  }
+  const durationMs = performance.now() - startedAt;
+  return {
+    name,
+    iterations,
+    packetBytes: expectedBytes,
+    checksum: expectedChecksum,
+    totalMs: Number(durationMs.toFixed(3)),
+    meanMs: Number((durationMs / iterations).toFixed(3)),
+  };
+}
+
+function runSnapshotBenchmark(options = {}) {
+  const iterations = options.iterations || 100;
+  const fixtures = createSnapshotFixtures(options);
+  const full = benchmarkPayload('full', fixtures.full, iterations);
+  const delta = benchmarkPayload('delta', fixtures.delta, iterations);
+  const usesDefaultFixture = options.seed === undefined
+    && options.dynamicEntityCount === undefined
+    && options.staticEntityCount === undefined
+    && options.deltaEntityCount === undefined;
+  if (usesDefaultFixture) {
+    const fullSignature = `${full.packetBytes}:${full.checksum}`;
+    const deltaSignature = `${delta.packetBytes}:${delta.checksum}`;
+    if (fullSignature !== DEFAULT_FULL_SIGNATURE || deltaSignature !== DEFAULT_DELTA_SIGNATURE) {
+      throw new Error(
+        `Snapshot behavior drifted: ${fullSignature}/${deltaSignature} != `
+        + `${DEFAULT_FULL_SIGNATURE}/${DEFAULT_DELTA_SIGNATURE}`,
+      );
+    }
+  }
+  return {
+    benchmark: 'snapshot',
+    seed: options.seed || 0x51A7BEEF,
+    full,
+    delta,
+  };
+}
+
+if (require.main === module) {
+  console.log(JSON.stringify(runSnapshotBenchmark(), null, 2));
+}
+
+module.exports = {
+  benchmarkPayload,
+  createSnapshotFixtures,
+  hashBytes,
+  runSnapshotBenchmark,
+};

--- a/server/package.json
+++ b/server/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "start": "node ./src/index.js",
     "dev": "nodemon ./src/index.js --watch ./src",
-    "test": "echo \"Error: no test specified\" && exit 1",
+    "test": "node --test test/*.test.js",
     "foreverprod": "forever start src/index.js"
   },
   "author": "",

--- a/server/package.json
+++ b/server/package.json
@@ -7,6 +7,9 @@
     "start": "node ./src/index.js",
     "dev": "nodemon ./src/index.js --watch ./src",
     "test": "node --test test/*.test.js",
+    "bench": "node bench/run.js",
+    "bench:collision": "node bench/collision.bench.js",
+    "bench:snapshot": "node bench/snapshot.bench.js",
     "foreverprod": "forever start src/index.js"
   },
   "author": "",

--- a/server/package.json
+++ b/server/package.json
@@ -10,6 +10,7 @@
     "bench": "node bench/run.js",
     "bench:collision": "node bench/collision.bench.js",
     "bench:snapshot": "node bench/snapshot.bench.js",
+    "bench:soak": "node bench/outbreak-soak.bench.js",
     "foreverprod": "forever start src/index.js"
   },
   "author": "",

--- a/server/src/game/Game.js
+++ b/server/src/game/Game.js
@@ -1,10 +1,12 @@
 const SAT = require('sat');
 const IdPool = require('./components/IdPool');
-const QuadTree = require('./components/Quadtree');
+const WorldIndex = require('./components/WorldIndex');
 const GameMap = require('./GameMap');
 const GlobalEntities = require('./GlobalEntities');
 const CombatDirector = require('./components/CombatDirector');
+const WorldEventDirector = require('./components/WorldEventDirector');
 const Player = require('./entities/Player');
+const api = require('../network/api');
 const helpers = require('../helpers');
 const config = require('../config');
 const filter = null;
@@ -34,6 +36,7 @@ class Game {
     this.map = new GameMap(this);
     this.globalEntities = new GlobalEntities(this);
     this.combatDirector = new CombatDirector(this);
+    this.worldEventDirector = new WorldEventDirector(this);
 
     this.entitiesQuadtree = null;
     this._removedEntitiesById = new Map();
@@ -47,7 +50,8 @@ class Game {
     this.map.initialize();
 
     const mapBoundary = this.map;
-    this.entitiesQuadtree = new QuadTree(mapBoundary, 10, 5);
+    this.entitiesQuadtree = new WorldIndex(mapBoundary, 512);
+    this.entitiesQuadtree.sync(this.entities);
   }
 
   tick(dt) {
@@ -62,8 +66,8 @@ class Game {
     if (metrics) metrics.recordPhase('entityUpdate', metrics.now() - phaseStartedAt);
 
     if (metrics) phaseStartedAt = metrics.now();
-    this.updateQuadtree(this.entitiesQuadtree, this.entities);
-    if (metrics) metrics.recordPhase('spatialIndexRebuild', metrics.now() - phaseStartedAt);
+    this.entitiesQuadtree.sync(this.entities);
+    if (metrics) metrics.recordPhase('spatialIndexSync', metrics.now() - phaseStartedAt);
 
     if (metrics) phaseStartedAt = metrics.now();
     const response = new SAT.Response();
@@ -81,6 +85,10 @@ class Game {
     if (metrics) phaseStartedAt = metrics.now();
     this.map.update(dt);
     if (metrics) metrics.recordPhase('mapUpdate', metrics.now() - phaseStartedAt);
+
+    if (metrics) phaseStartedAt = metrics.now();
+    this.worldEventDirector.update(dt);
+    if (metrics) metrics.recordPhase('worldEventDirector', metrics.now() - phaseStartedAt);
 
     if (metrics) phaseStartedAt = metrics.now();
     this.combatDirector.update();
@@ -395,7 +403,8 @@ class Game {
       }
     }
     if (data.chatMessage && typeof data.chatMessage === 'string') {
-      if (!this.combatDirector.handleCommand(player, data.chatMessage)) {
+      if (!this.worldEventDirector.handleCommand(player, data.chatMessage)
+        && !this.combatDirector.handleCommand(player, data.chatMessage)) {
         player.addChatMessage(data.chatMessage);
       }
     }
@@ -442,15 +451,6 @@ class Game {
       return null;
     }
     return data;
-  }
-
-  updateQuadtree(quadtree, entities) {
-    quadtree.clear();
-    for (const [id, entity] of entities) {
-      const collisionRect = entity.shape.boundary;
-      collisionRect.entity = entity;
-      quadtree.insert(collisionRect);
-    }
   }
 
   getAllEntities(player, includeStatic = true) {
@@ -595,6 +595,10 @@ class Game {
     player.isFirstLife = !!data.firstLife;
     if (client.account) {
       const account = client.account;
+      if (!Number.isFinite(Number(account.valorCrests))) account.valorCrests = 0;
+      api.get(`/valor/profile/${account.id}`, profile => {
+        if (!profile?.error && client.account) client.account.valorCrests = Number(profile.crests) || 0;
+      });
       if (account.skins && account.skins.equipped) {
         player.skin = account.skins.equipped;
         player.sword.skin = player.skin;
@@ -679,6 +683,7 @@ class Game {
     }
     this.entities.set(entity.id, entity);
     this.newEntities.add(entity);
+    if (this.entitiesQuadtree) this.entitiesQuadtree.upsertEntity(entity);
     return entity;
   }
 
@@ -694,6 +699,7 @@ class Game {
     if (entity.sword) this.removeEntity(entity.sword);
     if (entity.offhandSword) this.removeEntity(entity.offhandSword);
     this.entities.delete(entity?.id);
+    if (this.entitiesQuadtree) this.entitiesQuadtree.remove(entity);
     this.players.delete(entity);
     this.newEntities.delete(entity);
     this.removedEntities.add(entity);

--- a/server/src/game/Game.js
+++ b/server/src/game/Game.js
@@ -51,14 +51,21 @@ class Game {
   }
 
   tick(dt) {
+    const metrics = this.performanceMetrics;
+    let phaseStartedAt = metrics ? metrics.now() : 0;
     for (const [id, entity] of this.entities) {
       // Not a sword
       const entityType = entity.type;
       if (entityType === Types.Entity.Sword) continue;
       entity.update(dt);
     }
+    if (metrics) metrics.recordPhase('entityUpdate', metrics.now() - phaseStartedAt);
 
+    if (metrics) phaseStartedAt = metrics.now();
     this.updateQuadtree(this.entitiesQuadtree, this.entities);
+    if (metrics) metrics.recordPhase('spatialIndexRebuild', metrics.now() - phaseStartedAt);
+
+    if (metrics) phaseStartedAt = metrics.now();
     const response = new SAT.Response();
     for (const [id, entity] of this.entities) {
       if (entity.removed) continue;
@@ -69,8 +76,15 @@ class Game {
 
       this.processCollisions(entity, response, dt);
     }
+    if (metrics) metrics.recordPhase('collisionProcessing', metrics.now() - phaseStartedAt);
+
+    if (metrics) phaseStartedAt = metrics.now();
     this.map.update(dt);
+    if (metrics) metrics.recordPhase('mapUpdate', metrics.now() - phaseStartedAt);
+
+    if (metrics) phaseStartedAt = metrics.now();
     this.combatDirector.update();
+    if (metrics) metrics.recordPhase('combatDirector', metrics.now() - phaseStartedAt);
   }
 
   processCollisions(entity, response, dt) {
@@ -409,7 +423,8 @@ class Game {
       client.fullSync = false;
       data.fullSync = true;
       data.selfId = entity.id;
-      data.entities = this.getAllEntities(entity);
+      // Spectator full sync already carries the same static world in mapData.
+      data.entities = this.getAllEntities(entity, !spectator.isSpectating);
       data.globalEntities = this.globalEntities.getAll();
     } else {
       data.entities = this.getEntitiesChanges(entity);
@@ -438,12 +453,14 @@ class Game {
     }
   }
 
-  getAllEntities(player) {
+  getAllEntities(player, includeStatic = true) {
     const entities = {};
 
-    for (const entity of this.entities.values()) {
-      if (entity.isStatic) {
-        entities[entity.id] = entity.state.get();
+    if (includeStatic) {
+      for (const entity of this.entities.values()) {
+        if (entity.isStatic) {
+          entities[entity.id] = entity.state.get();
+        }
       }
     }
 

--- a/server/src/game/Game.js
+++ b/server/src/game/Game.js
@@ -3,6 +3,7 @@ const IdPool = require('./components/IdPool');
 const QuadTree = require('./components/Quadtree');
 const GameMap = require('./GameMap');
 const GlobalEntities = require('./GlobalEntities');
+const CombatDirector = require('./components/CombatDirector');
 const Player = require('./entities/Player');
 const helpers = require('../helpers');
 const config = require('../config');
@@ -10,6 +11,11 @@ const filter = null;
 const Types = require('./Types');
 const { getBannedIps } = require('../moderation');
 const { filterChatMessage } = helpers;
+const {
+  normalizeAngle,
+  sanitizeInputEvents,
+  sanitizeMouse,
+} = require('./components/InputSanitizer');
 
 function hasOwnProperties(obj) {
   for (const key in obj) {
@@ -27,6 +33,7 @@ class Game {
     this.idPool = new IdPool();
     this.map = new GameMap(this);
     this.globalEntities = new GlobalEntities(this);
+    this.combatDirector = new CombatDirector(this);
 
     this.entitiesQuadtree = null;
     this._removedEntitiesById = new Map();
@@ -63,6 +70,7 @@ class Game {
       this.processCollisions(entity, response, dt);
     }
     this.map.update(dt);
+    this.combatDirector.update();
   }
 
   processCollisions(entity, response, dt) {
@@ -300,7 +308,7 @@ class Game {
     if (!player || player.removed) return;
 
     if (data.inputs) {
-      for (const input of data.inputs) {
+      for (const input of sanitizeInputEvents(data.inputs)) {
         if (input.inputDown) {
           player.inputs.inputDown(input.inputType);
         } else {
@@ -314,14 +322,16 @@ class Game {
       player.reportedChestCombo = raw >= 8 ? Math.max(1, Math.min(2, (raw >> 3) / 100)) : 1;
       player.reportedChestAt = Date.now();
     }
-    if (data.angle && !isNaN(data.angle)) {
-      player.angle = Number(data.angle);
+    if (data.angle !== undefined && data.angle !== null) {
+      const angle = normalizeAngle(data.angle);
+      if (angle !== null) player.angle = angle;
     }
     if (data.mouse) {
-      if (data.mouse.force === 0) {
+      const mouse = sanitizeMouse(data.mouse);
+      if (!mouse || mouse.force === 0) {
         player.mouse = null;
       } else {
-        player.mouse = data.mouse;
+        player.mouse = mouse;
       }
     }
     if (data.selectedEvolution) {
@@ -371,7 +381,9 @@ class Game {
       }
     }
     if (data.chatMessage && typeof data.chatMessage === 'string') {
-      player.addChatMessage(data.chatMessage);
+      if (!this.combatDirector.handleCommand(player, data.chatMessage)) {
+        player.addChatMessage(data.chatMessage);
+      }
     }
   }
   createPayload(client) {
@@ -561,6 +573,8 @@ class Game {
     client.fullSync = true;
     client.player = player;
     player.client = client;
+    player.lastKilledByKey = client.lastKilledByKey || null;
+    client.lastKilledByKey = null;
     player.isFirstLife = !!data.firstLife;
     if (client.account) {
       const account = client.account;
@@ -603,6 +617,7 @@ class Game {
 
         player.respawnedAt = Date.now();
         player.respawnKillerName = pendingRespawn.killerName;
+        player.lastKilledByKey = pendingRespawn.killerIdentity || player.lastKilledByKey;
 
         client.pendingRespawn = null;
       } else {
@@ -667,6 +682,7 @@ class Game {
     this.removedEntities.add(entity);
     this._removedEntitiesById.set(entity.id, entity);
     entity.removed = true;
+    if (entity.type === Types.Entity.Player) this.combatDirector.forgetPlayer(entity);
   }
 
   handleNickname(nickname) {

--- a/server/src/game/GlobalEntities.js
+++ b/server/src/game/GlobalEntities.js
@@ -1,7 +1,7 @@
 const Types = require('./Types');
 
 class GlobalEntities {
-  static fields = ['id', 'type', 'name', 'coins', 'tokens', 'shapeData', 'removed', 'angle', 'account', 'healthPercent', 'skin', 'size', 'rarity'];
+  static fields = ['id', 'type', 'name', 'coins', 'tokens', 'shapeData', 'removed', 'angle', 'account', 'healthPercent', 'skin', 'size', 'rarity', 'valorCrests'];
 
   constructor(game) {
     this.game = game;

--- a/server/src/game/Types.js
+++ b/server/src/game/Types.js
@@ -45,11 +45,13 @@ const Entity = {
   SandBall: 42,
   Ore: 43,
   AmbientShrub: 44,
+  Zombie: 45,
 };
 
 const Mobs = [
   Entity.Wolf, Entity.Bunny, Entity.Moose, Entity.Yeti, Entity.Santa, Entity.Chimera, Entity.Roku, Entity.Ancient, Entity.Cat, Entity.Fish, Entity.AngryFish, Entity.IceSpirit,
   Entity.Sphinx,
+  Entity.Zombie,
 ];
 const Groups = {
   Obstacles: [

--- a/server/src/game/components/CombatDirector.js
+++ b/server/src/game/components/CombatDirector.js
@@ -168,7 +168,7 @@ class CombatDirector {
     const command = rawMessage.trim().toLowerCase().split(/\s+/, 1)[0];
     switch (command) {
       case '/help':
-        player.setSystemMessage('/stats /dash /bounty /players');
+        player.setSystemMessage('/stats /dash /bounty /players /event /valor /valor top');
         return true;
       case '/stats':
         player.setSystemMessage(`K ${player.kills} A ${player.assists} streak ${player.killStreak}`);

--- a/server/src/game/components/CombatDirector.js
+++ b/server/src/game/components/CombatDirector.js
@@ -1,0 +1,194 @@
+const Types = require('../Types');
+
+const DEFAULTS = Object.freeze({
+  assistWindowMs: 12000,
+  encounterWindowMs: 120000,
+  ledgerCleanupIntervalMs: 30000,
+  minimumAssistShare: 0.12,
+  killHealPercent: 0.06,
+  repeatRewardMultipliers: [1, 0.55, 0.2, 0],
+});
+
+class CombatDirector {
+  constructor(game, options = {}) {
+    this.game = game;
+    this.config = { ...DEFAULTS, ...options };
+    this.damageLedger = new Map();
+    this.encounters = new Map();
+    this.lastCleanupAt = 0;
+  }
+
+  recordDamage(victim, attacker, damage, now = Date.now()) {
+    if (!this.isPlayer(victim) || !this.isPlayer(attacker) || victim === attacker) return;
+    if (!Number.isFinite(damage) || damage <= 0) return;
+
+    let attackers = this.damageLedger.get(victim.id);
+    if (!attackers) {
+      attackers = new Map();
+      this.damageLedger.set(victim.id, attackers);
+    }
+
+    const entry = attackers.get(attacker.id) || { damage: 0, lastHitAt: now };
+    entry.damage += damage;
+    entry.lastHitAt = now;
+    attackers.set(attacker.id, entry);
+  }
+
+  handleKill(victim, killer, now = Date.now()) {
+    if (!this.isPlayer(victim)) return null;
+
+    const victimStreak = victim.killStreak || 0;
+    victim.killStreak = 0;
+    victim.bounty = 0;
+    victim.lastKilledByKey = this.identity(killer);
+
+    if (!this.isPlayer(killer) || killer === victim) {
+      this.damageLedger.delete(victim.id);
+      return null;
+    }
+
+    killer.killStreak = (killer.killStreak || 0) + 1;
+    const repeatMultiplier = this.registerEncounter(killer, victim, now);
+    const victimCoins = Math.max(0, Number(victim.levels?.coins) || 0);
+    const bounty = this.calculateBounty(victimStreak, victimCoins);
+    const bountyAward = Math.round(bounty * repeatMultiplier);
+
+    if (bountyAward > 0) killer.levels?.addCoins(bountyAward);
+    if (killer.health && !killer.health.isDead) {
+      killer.health.gain(killer.health.max.value * this.config.killHealPercent);
+    }
+
+    const revenge = killer.lastKilledByKey === this.identity(victim);
+    const revengeAward = revenge
+      ? Math.round(Math.min(1500, Math.max(50, victimCoins * 0.04)) * repeatMultiplier)
+      : 0;
+    if (revengeAward > 0) killer.levels?.addCoins(revengeAward);
+    killer.lastKilledByKey = null;
+
+    const assists = this.awardAssists(victim, killer, victimCoins, repeatMultiplier, now);
+    killer.bounty = this.calculateBounty(killer.killStreak, Number(killer.levels?.coins) || 0);
+    this.damageLedger.delete(victim.id);
+
+    return {
+      streak: killer.killStreak,
+      bountyAward,
+      revengeAward,
+      repeatMultiplier,
+      assists,
+    };
+  }
+
+  awardAssists(victim, killer, victimCoins, repeatMultiplier, now) {
+    const attackers = this.damageLedger.get(victim.id);
+    if (!attackers) return [];
+
+    const victimMaxHealth = Math.max(1, Number(victim.health?.max?.value) || 1);
+    const awards = [];
+    for (const [attackerId, entry] of attackers) {
+      if (attackerId === killer.id) continue;
+      if (now - entry.lastHitAt > this.config.assistWindowMs) continue;
+
+      const assistant = this.game?.entities?.get(attackerId);
+      if (!this.isPlayer(assistant) || assistant.removed) continue;
+
+      const share = Math.min(1, entry.damage / victimMaxHealth);
+      if (share < this.config.minimumAssistShare) continue;
+
+      const assistRepeatMultiplier = this.registerEncounter(assistant, victim, now);
+      const rewardMultiplier = Math.min(repeatMultiplier, assistRepeatMultiplier);
+      const baseAward = Math.min(1000, Math.max(25, victimCoins * 0.025));
+      const coins = Math.round(baseAward * share * rewardMultiplier);
+      if (coins > 0) assistant.levels?.addCoins(coins);
+      assistant.assists = (assistant.assists || 0) + 1;
+      awards.push({ playerId: assistant.id, coins, share });
+    }
+    return awards;
+  }
+
+  calculateBounty(streak, coins) {
+    if (streak < 3) return 0;
+    const safeCoins = Math.max(0, Number(coins) || 0);
+    return Math.round(Math.min(10000, streak * streak * 85 + safeCoins * 0.006));
+  }
+
+  registerEncounter(killer, victim, now) {
+    const key = `${this.identity(killer)}>${this.identity(victim)}`;
+    const cutoff = now - this.config.encounterWindowMs;
+    const recent = (this.encounters.get(key) || []).filter(timestamp => timestamp >= cutoff);
+    const index = Math.min(recent.length, this.config.repeatRewardMultipliers.length - 1);
+    recent.push(now);
+    this.encounters.set(key, recent);
+    return this.config.repeatRewardMultipliers[index];
+  }
+
+  identity(player) {
+    if (!player) return 'world';
+    if (player.client?.account?.id) return `account:${player.client.account.id}`;
+    if (player.client?.ip) return `ip:${player.client.ip}`;
+    return `entity:${player.id}`;
+  }
+
+  isPlayer(entity) {
+    return !!entity && entity.type === Types.Entity.Player;
+  }
+
+  update(now = Date.now()) {
+    if (now - this.lastCleanupAt < this.config.ledgerCleanupIntervalMs) return;
+    this.lastCleanupAt = now;
+
+    const damageCutoff = now - this.config.assistWindowMs;
+    for (const [victimId, attackers] of this.damageLedger) {
+      for (const [attackerId, entry] of attackers) {
+        if (entry.lastHitAt < damageCutoff) attackers.delete(attackerId);
+      }
+      if (attackers.size === 0) this.damageLedger.delete(victimId);
+    }
+
+    const encounterCutoff = now - this.config.encounterWindowMs;
+    for (const [key, timestamps] of this.encounters) {
+      const recent = timestamps.filter(timestamp => timestamp >= encounterCutoff);
+      if (recent.length === 0) this.encounters.delete(key);
+      else this.encounters.set(key, recent);
+    }
+  }
+
+  forgetPlayer(player) {
+    if (!player) return;
+    this.damageLedger.delete(player.id);
+    for (const attackers of this.damageLedger.values()) attackers.delete(player.id);
+  }
+
+  handleCommand(player, rawMessage) {
+    if (typeof rawMessage !== 'string' || !rawMessage.startsWith('/')) return false;
+
+    const now = Date.now();
+    if (now - (player.lastCommandAt || 0) < 500) return true;
+    player.lastCommandAt = now;
+
+    const command = rawMessage.trim().toLowerCase().split(/\s+/, 1)[0];
+    switch (command) {
+      case '/help':
+        player.setSystemMessage('/stats /dash /bounty /players');
+        return true;
+      case '/stats':
+        player.setSystemMessage(`K ${player.kills} A ${player.assists} streak ${player.killStreak}`);
+        return true;
+      case '/dash':
+        player.setSystemMessage(`Dash: ${player.dash.status} (double-tap movement)`);
+        return true;
+      case '/bounty':
+        player.setSystemMessage(`Bounty: ${Math.round(player.bounty || 0)} coins`);
+        return true;
+      case '/players':
+        player.setSystemMessage(`${this.game.players.size}/${this.game.maxPlayers} players online`);
+        return true;
+      default:
+        player.setSystemMessage('Unknown command. Try /help');
+        return true;
+    }
+  }
+}
+
+CombatDirector.DEFAULTS = DEFAULTS;
+
+module.exports = CombatDirector;

--- a/server/src/game/components/DashSystem.js
+++ b/server/src/game/components/DashSystem.js
@@ -1,0 +1,80 @@
+const Types = require('../Types');
+
+const DIRECTION_ANGLES = Object.freeze({
+  [Types.Input.Up]: -Math.PI / 2,
+  [Types.Input.Right]: 0,
+  [Types.Input.Down]: Math.PI / 2,
+  [Types.Input.Left]: Math.PI,
+});
+
+const DEFAULTS = Object.freeze({
+  doubleTapWindowMs: 260,
+  cooldownSeconds: 3,
+  durationSeconds: 0.18,
+  speedMultiplier: 2.15,
+});
+
+class DashSystem {
+  constructor(player, options = {}) {
+    this.player = player;
+    this.config = { ...DEFAULTS, ...options };
+    this.lastTapAt = new Map();
+    this.cooldown = 0;
+    this.remaining = 0;
+    this.direction = null;
+  }
+
+  onDirectionInput(inputType, now = Date.now()) {
+    if (!Object.prototype.hasOwnProperty.call(DIRECTION_ANGLES, inputType)) return false;
+
+    const previousTap = this.lastTapAt.get(inputType) || 0;
+    this.lastTapAt.set(inputType, now);
+
+    if (now - previousTap > this.config.doubleTapWindowMs) return false;
+    if (!this.canActivate()) return false;
+
+    this.direction = DIRECTION_ANGLES[inputType];
+    this.remaining = this.config.durationSeconds;
+    this.cooldown = this.config.cooldownSeconds;
+    this.lastTapAt.clear();
+    return true;
+  }
+
+  canActivate() {
+    const player = this.player;
+    if (this.cooldown > 0 || this.remaining > 0) return false;
+    if (!player || player.removed || player.inSafezone) return false;
+    if (player.modifiers?.stunned || player.hypnotizedBy) return false;
+    if (player.cards?.choosingCard && player.cards.instantSelect) return false;
+    return true;
+  }
+
+  update(dt) {
+    const safeDt = Number.isFinite(dt) && dt > 0 ? dt : 0;
+    this.cooldown = Math.max(0, this.cooldown - safeDt);
+    this.remaining = Math.max(0, this.remaining - safeDt);
+
+    if (this.remaining <= 0 || this.direction === null) return;
+
+    this.player.speed.multiplier *= this.config.speedMultiplier;
+    this.player.movementDirection = this.direction;
+    this.player.modifiers.dashNoclip = true;
+    this.player.modifiers.dashDirection = this.direction;
+  }
+
+  interrupt() {
+    this.remaining = 0;
+    this.direction = null;
+  }
+
+  get status() {
+    if (this.remaining > 0) return 'active';
+    if (this.cooldown > 0) return `${this.cooldown.toFixed(1)}s`;
+    return 'ready';
+  }
+}
+
+DashSystem.DEFAULTS = DEFAULTS;
+DashSystem.DIRECTION_ANGLES = DIRECTION_ANGLES;
+
+module.exports = DashSystem;

--- a/server/src/game/components/Health.js
+++ b/server/src/game/components/Health.js
@@ -20,9 +20,18 @@ class Health {
   }
 
   damaged(damage, opts = {}) {
+    if (this.isDead) return 0;
+
+    const safeDamage = Number(damage);
+    const maxHealth = Number(this.max.value);
+    if (!Number.isFinite(safeDamage) || safeDamage <= 0) return 0;
+    if (!Number.isFinite(maxHealth) || maxHealth <= 0) return 0;
+
     const { source = 'melee' } = opts;
-    const coef = damage / this.max.value;
-    this.percent -= coef;
+    const healthBefore = this.percent * maxHealth;
+    const appliedDamage = Math.min(safeDamage, healthBefore);
+    const coef = appliedDamage / maxHealth;
+    this.percent = appliedDamage >= healthBefore ? 0 : this.percent - coef;
     this.lastDamage = Date.now();
 
     const newWaitUntil = this.lastDamage + this.regenWait.value * Health.sourceWaitMult(source);
@@ -30,19 +39,36 @@ class Health {
       this.regenWaitUntil = newWaitUntil;
     }
 
-    if (this.percent <= 0) {
-      this.percent = 0;
+    if (this.percent === 0) {
       this.isDead = true;
     }
+    return appliedDamage;
   }
 
   gain(amount) {
-    this.percent = Math.min(this.percent + amount / this.max.value, 1);
+    if (this.isDead) return 0;
+
+    const safeAmount = Number(amount);
+    const maxHealth = Number(this.max.value);
+    if (!Number.isFinite(safeAmount) || safeAmount <= 0) return 0;
+    if (!Number.isFinite(maxHealth) || maxHealth <= 0) return 0;
+
+    const before = this.percent;
+    this.percent = Math.min(this.percent + safeAmount / maxHealth, 1);
+    return (this.percent - before) * maxHealth;
   }
 
   update(dt) {
+    if (this.isDead) return;
     if (Date.now() < this.regenWaitUntil) return;
-    const coef = this.regen.value / this.max.value * dt;
+    if (!Number.isFinite(dt) || dt <= 0) return;
+
+    const maxHealth = Number(this.max.value);
+    const regeneration = Number(this.regen.value);
+    if (!Number.isFinite(maxHealth) || maxHealth <= 0) return;
+    if (!Number.isFinite(regeneration) || regeneration <= 0) return;
+
+    const coef = regeneration / maxHealth * dt;
     this.percent = Math.min(this.percent + coef, 1);
   }
 

--- a/server/src/game/components/InputSanitizer.js
+++ b/server/src/game/components/InputSanitizer.js
@@ -1,0 +1,44 @@
+const Types = require('../Types');
+
+const VALID_INPUTS = new Set(Object.values(Types.Input));
+const MAX_INPUT_EVENTS = 16;
+const MAX_MOUSE_FORCE = 150;
+
+function normalizeAngle(value) {
+  const angle = Number(value);
+  if (!Number.isFinite(angle)) return null;
+  return Math.atan2(Math.sin(angle), Math.cos(angle));
+}
+
+function sanitizeInputEvents(inputs) {
+  if (!Array.isArray(inputs)) return [];
+
+  const sanitized = [];
+  for (const input of inputs.slice(0, MAX_INPUT_EVENTS)) {
+    const inputType = Number(input?.inputType);
+    if (!Number.isInteger(inputType) || !VALID_INPUTS.has(inputType)) continue;
+    sanitized.push({ inputType, inputDown: input?.inputDown === true });
+  }
+  return sanitized;
+}
+
+function sanitizeMouse(mouse) {
+  if (!mouse || typeof mouse !== 'object') return null;
+
+  const angle = normalizeAngle(mouse.angle);
+  const force = Number(mouse.force);
+  if (angle === null || !Number.isFinite(force)) return null;
+
+  return {
+    angle,
+    force: Math.max(0, Math.min(MAX_MOUSE_FORCE, force)),
+  };
+}
+
+module.exports = {
+  MAX_INPUT_EVENTS,
+  MAX_MOUSE_FORCE,
+  normalizeAngle,
+  sanitizeInputEvents,
+  sanitizeMouse,
+};

--- a/server/src/game/components/WorldEventDirector.js
+++ b/server/src/game/components/WorldEventDirector.js
@@ -1,0 +1,310 @@
+const { randomUUID } = require('crypto');
+const Types = require('../Types');
+const Zombie = require('../entities/Zombie');
+const api = require('../../network/api');
+
+const PHASE = Object.freeze({ IDLE: 'idle', WARNING: 'warning', ACTIVE: 'active' });
+const MIN_DELAY = 12 * 60;
+const MAX_DELAY = 18 * 60;
+const WARNING_SECONDS = 20;
+const MAX_DURATION = 8 * 60;
+const RING_RADIUS = 1200;
+const RING_VARIANTS = Object.freeze([
+  ...Array(16).fill(1), ...Array(3).fill(2), 3,
+]);
+
+function accountId(player) {
+  return Number(player?.client?.account?.id) || null;
+}
+
+class WorldEventDirector {
+  constructor(game, options = {}) {
+    this.game = game;
+    this.random = options.random || Math.random;
+    this.phase = PHASE.IDLE;
+    this.activePlay = 0;
+    this.warningElapsed = 0;
+    this.eventElapsed = 0;
+    this.nextAt = this.randomDelay();
+    this.eventId = null;
+    this.ringRecipients = new Set();
+    this.zombieIds = new Set();
+    this.contributions = new Map();
+    this.suspended = null;
+    this.lastResult = null;
+  }
+
+  randomDelay() {
+    return MIN_DELAY + this.random() * (MAX_DELAY - MIN_DELAY);
+  }
+
+  realPlayers() {
+    return Array.from(this.game.players).filter(p => p && !p.removed && !p.isBot && p.type === Types.Entity.Player);
+  }
+
+  eligiblePlayers() {
+    return this.realPlayers().filter(p => !p.inSafezone && !p.cards?.isTutorial);
+  }
+
+  playerKey(player) {
+    const id = accountId(player);
+    if (id) return `account:${id}`;
+    const clientKey = player?.client?.id ?? player?.client?.socket?.remoteAddress ?? player?.id;
+    return `guest:${clientKey}`;
+  }
+
+  update(dt) {
+    if (!Number.isFinite(dt) || dt <= 0) return;
+    if (this.phase === PHASE.IDLE) {
+      if (this.eligiblePlayers().length === 0) return;
+      this.activePlay += dt;
+      if (this.activePlay >= this.nextAt) this.beginWarning();
+      return;
+    }
+    if (this.phase === PHASE.WARNING) {
+      if (this.eligiblePlayers().length === 0) return;
+      this.warningElapsed += dt;
+      if (this.warningElapsed >= WARNING_SECONDS) this.beginOutbreak();
+      return;
+    }
+
+    this.eventElapsed += dt;
+    this.removeUnexpectedNpcs();
+    for (const player of this.realPlayers()) this.trySpawnRing(player);
+    this.pruneZombies();
+    if (this.eventElapsed >= MAX_DURATION) this.finish(false, 'timeout');
+    else if (this.ringRecipients.size > 0 && this.zombieIds.size === 0) this.finish(true, 'cleared');
+  }
+
+  beginWarning() {
+    this.phase = PHASE.WARNING;
+    this.warningElapsed = 0;
+    this.broadcast('Zombie outbreak in 20 seconds! Leave shelter to join the defense.');
+  }
+
+  beginOutbreak() {
+    this.phase = PHASE.ACTIVE;
+    this.eventElapsed = 0;
+    this.eventId = randomUUID();
+    this.ringRecipients.clear();
+    this.zombieIds.clear();
+    this.contributions.clear();
+    this.suspendNpcs();
+    for (const player of this.realPlayers()) this.trySpawnRing(player);
+    this.broadcast('The zombie outbreak has begun!');
+  }
+
+  isRegularNpc(entity) {
+    if (!entity || entity.removed || entity.type === Types.Entity.Zombie) return false;
+    return (entity.type === Types.Entity.Player && entity.isBot) || Types.Groups.Mobs.includes(entity.type);
+  }
+
+  suspendNpcs() {
+    if (this.suspended) return;
+    const savedAiCount = this.game.map.aiPlayersCount;
+    const definitions = [];
+    const timers = [];
+    let botCount = 0;
+    this.game.map.aiPlayersCount = 0;
+    for (const timer of Array.from(this.game.map.entityTimers)) {
+      const type = timer?.definition?.type;
+      if (type === Types.Entity.Player || Types.Groups.Mobs.includes(type)) {
+        timers.push(timer);
+        this.game.map.entityTimers.delete(timer);
+      }
+    }
+    for (const entity of Array.from(this.game.entities.values())) {
+      if (!this.isRegularNpc(entity)) continue;
+      if (entity.type === Types.Entity.Player && entity.isBot) botCount += 1;
+      definitions.push(entity.originalDefinition ? { ...entity.originalDefinition } : null);
+      entity.respawnable = false;
+      this.game.removeEntity(entity);
+    }
+    this.suspended = { savedAiCount, botCount, definitions: definitions.filter(Boolean), timers };
+  }
+
+  removeUnexpectedNpcs() {
+    for (const entity of Array.from(this.game.entities.values())) {
+      if (this.isRegularNpc(entity)) {
+        entity.respawnable = false;
+        this.game.removeEntity(entity);
+      }
+    }
+  }
+
+  restoreNpcs() {
+    if (!this.suspended) return;
+    this.game.map.aiPlayersCount = this.suspended.savedAiCount;
+    for (const timer of this.suspended.timers) this.game.map.entityTimers.add(timer);
+    for (const definition of this.suspended.definitions) {
+      if (definition.type !== Types.Entity.Player) this.game.map.addEntity(definition);
+    }
+    for (let i = 0; i < this.suspended.botCount; i++) this.game.map.spawnPlayerBot();
+    this.suspended = null;
+  }
+
+  trySpawnRing(player) {
+    if (!player || player.removed || player.inSafezone || player.cards?.isTutorial) return false;
+    const key = this.playerKey(player);
+    if (this.ringRecipients.has(key)) return false;
+    // A Player-derived zombie owns one Sword too. Capacity is checked for the whole ring.
+    if (this.game.entities.size + RING_VARIANTS.length * 2 > this.game.maxEntities) return false;
+
+    const start = ((player.id || 0) * 2.399963229728653) % (Math.PI * 2);
+    const spawned = [];
+    for (let i = 0; i < RING_VARIANTS.length; i++) {
+      const zombie = new Zombie(this.game, RING_VARIANTS[i], this.eventId);
+      const baseAngle = start + i / RING_VARIANTS.length * Math.PI * 2;
+      const point = this.ringPoint(player, baseAngle);
+      zombie.shape.x = point.x;
+      zombie.shape.y = point.y;
+      if (!this.game.addEntity(zombie)) {
+        for (const prior of spawned) this.game.removeEntity(prior);
+        this.game.removeEntity(zombie.sword);
+        return false;
+      }
+      spawned.push(zombie);
+      this.zombieIds.add(zombie.id);
+    }
+    this.ringRecipients.add(key);
+    return true;
+  }
+
+  ringPoint(player, baseAngle) {
+    const safe = this.game.map.safezone?.shape;
+    const tutorial = this.game.map.tutorialSafezone?.shape;
+    const minX = Number.isFinite(Number(this.game.map.x)) ? Number(this.game.map.x) : -Infinity;
+    const minY = Number.isFinite(Number(this.game.map.y)) ? Number(this.game.map.y) : -Infinity;
+    const maxX = Number.isFinite(this.game.map.width) ? minX + this.game.map.width : Infinity;
+    const maxY = Number.isFinite(this.game.map.height) ? minY + this.game.map.height : Infinity;
+    for (let attempt = 0; attempt < 72; attempt++) {
+      const angle = baseAngle + attempt * Math.PI * 2 / 72;
+      const x = player.shape.x + Math.cos(angle) * RING_RADIUS;
+      const y = player.shape.y + Math.sin(angle) * RING_RADIUS;
+      if (x < minX || x > maxX || y < minY || y > maxY) continue;
+      if (safe?.isPointInside?.(x, y) || tutorial?.isPointInside?.(x, y)) continue;
+      return { x, y };
+    }
+    return {
+      x: player.shape.x + Math.cos(baseAngle) * RING_RADIUS,
+      y: player.shape.y + Math.sin(baseAngle) * RING_RADIUS,
+    };
+  }
+
+  pruneZombies() {
+    for (const id of Array.from(this.zombieIds)) {
+      const zombie = this.game.entities.get(id);
+      if (!zombie || zombie.removed) this.zombieIds.delete(id);
+    }
+  }
+
+  recordContribution(player, damage, killed) {
+    if (this.phase !== PHASE.ACTIVE || !player || player.isBot) return;
+    const key = this.playerKey(player);
+    let entry = this.contributions.get(key);
+    if (!entry) {
+      entry = { player, accountId: accountId(player), damage: 0, kills: 0 };
+      this.contributions.set(key, entry);
+    }
+    entry.player = player;
+    entry.damage += Math.max(0, Number(damage) || 0);
+    if (killed) entry.kills += 1;
+  }
+
+  finish(success, reason) {
+    const resultId = this.eventId;
+    for (const id of Array.from(this.zombieIds)) {
+      const zombie = this.game.entities.get(id);
+      if (zombie) this.game.removeEntity(zombie);
+    }
+    this.zombieIds.clear();
+    this.restoreNpcs();
+    if (success) this.awardValor(resultId);
+    this.lastResult = { id: resultId, success, reason, elapsed: this.eventElapsed };
+    this.broadcast(success ? 'Outbreak cleared! Valor has been awarded.' : 'Outbreak failed. The undead survivors have withdrawn.');
+    this.phase = PHASE.IDLE;
+    this.activePlay = 0;
+    this.warningElapsed = 0;
+    this.eventElapsed = 0;
+    this.nextAt = this.randomDelay();
+    this.eventId = null;
+    this.ringRecipients.clear();
+    this.contributions.clear();
+  }
+
+  awardValor(eventId) {
+    const qualifying = Array.from(this.contributions.values())
+      .filter(c => c.accountId && (c.damage >= 200 || c.kills >= 2));
+    if (!qualifying.length) return;
+    qualifying.sort((a, b) => b.damage - a.damage || b.kills - a.kills || a.accountId - b.accountId);
+    const mvpId = qualifying[0].accountId;
+    const awards = qualifying.map(c => ({
+      accountId: c.accountId,
+      crests: 5 + (c.accountId === mvpId ? 1 : 0),
+      zombieKills: c.kills,
+      mvp: c.accountId === mvpId,
+    }));
+    this.postAwardsWithRetry({ outbreakId: eventId, awards }, 0);
+  }
+
+  postAwardsWithRetry(payload, attempt) {
+    api.post('/valor/award', payload, response => {
+      if (response?.error) {
+        if (attempt < 3) setTimeout(() => this.postAwardsWithRetry(payload, attempt + 1), 500 * (2 ** attempt));
+        return;
+      }
+      for (const profile of response?.profiles || []) {
+        for (const player of this.realPlayers()) {
+          if (accountId(player) === Number(profile.accountId) && player.client?.account) {
+            player.client.account.valorCrests = Number(profile.crests) || 0;
+          }
+        }
+      }
+    });
+  }
+
+  handleCommand(player, rawMessage) {
+    if (typeof rawMessage !== 'string' || !rawMessage.startsWith('/')) return false;
+    const parts = rawMessage.trim().toLowerCase().split(/\s+/);
+    if (parts[0] === '/event') {
+      const now = Date.now();
+      if (now - (player.lastWorldEventCommandAt || 0) < 500) return true;
+      player.lastWorldEventCommandAt = now;
+      const contribution = this.contributions.get(this.playerKey(player)) || { damage: 0, kills: 0 };
+      if (this.phase === PHASE.IDLE) player.setSystemMessage(`Next outbreak after ${Math.ceil(Math.max(0, this.nextAt - this.activePlay))}s of active play.`);
+      else if (this.phase === PHASE.WARNING) player.setSystemMessage(`Outbreak warning: ${Math.ceil(WARNING_SECONDS - this.warningElapsed)}s. Your contribution: 0 damage, 0 kills.`);
+      else player.setSystemMessage(`Outbreak: ${this.zombieIds.size} enemies, ${Math.floor(this.eventElapsed)}s elapsed. You: ${Math.round(contribution.damage)} damage, ${contribution.kills} kills.`);
+      return true;
+    }
+    if (parts[0] === '/valor') {
+      const now = Date.now();
+      if (now - (player.lastWorldEventCommandAt || 0) < 500) return true;
+      player.lastWorldEventCommandAt = now;
+      if (parts[1] === 'top') {
+        api.get('/valor/top?limit=10', data => {
+          if (data?.error) return player.setSystemMessage('Valor leaderboard is temporarily unavailable.');
+          const text = (data?.profiles || []).map((p, i) => `${i + 1}. ${p.username}: ${p.crests}`).join(' | ');
+          player.setSystemMessage(text || 'No Valor Crests have been earned yet.');
+        });
+      } else if (!accountId(player)) {
+        player.setSystemMessage('Guests can fight in outbreaks, but Valor Crests require an account.');
+      } else {
+        api.get(`/valor/profile/${accountId(player)}`, data => {
+          if (data?.error) return player.setSystemMessage('Your Valor profile is temporarily unavailable.');
+          player.setSystemMessage(`Valor: ${data.crests || 0} Crests, ${data.outbreaksCleared || 0} clears, ${data.zombieKills || 0} zombie kills, ${data.mvpCount || 0} MVPs.`);
+        });
+      }
+      return true;
+    }
+    return false;
+  }
+
+  broadcast(message) {
+    for (const player of this.realPlayers()) player.setSystemMessage(message);
+  }
+}
+
+WorldEventDirector.PHASE = PHASE;
+WorldEventDirector.RING_VARIANTS = RING_VARIANTS;
+WorldEventDirector.constants = { MIN_DELAY, MAX_DELAY, WARNING_SECONDS, MAX_DURATION, RING_RADIUS };
+module.exports = WorldEventDirector;

--- a/server/src/game/components/WorldIndex.js
+++ b/server/src/game/components/WorldIndex.js
@@ -1,0 +1,175 @@
+const { rectangleRectangle } = require('../collisions');
+
+class WorldIndex {
+  constructor(boundary, cellSize = 512) {
+    this.boundary = boundary;
+    this.cellSize = cellSize;
+    this.staticGrid = new Map();
+    this.dynamicGrid = new Map();
+    this.records = new Map();
+    this.queryGeneration = 0;
+    this.anonymousId = -1;
+  }
+
+  _cellRange(rectangle) {
+    return {
+      minX: Math.floor(rectangle.x / this.cellSize),
+      // Collision boundaries are inclusive, so an item ending exactly on a
+      // cell edge must also be visible to a query starting on that edge.
+      maxX: Math.floor((rectangle.x + Math.max(0, rectangle.width)) / this.cellSize),
+      minY: Math.floor(rectangle.y / this.cellSize),
+      maxY: Math.floor((rectangle.y + Math.max(0, rectangle.height)) / this.cellSize),
+    };
+  }
+
+  _cellKeys(rectangle) {
+    const range = this._cellRange(rectangle);
+    const keys = [];
+    for (let x = range.minX; x <= range.maxX; x++) {
+      for (let y = range.minY; y <= range.maxY; y++) keys.push(`${x}:${y}`);
+    }
+    return keys;
+  }
+
+  _sameKeys(left, right) {
+    if (left.length !== right.length) return false;
+    for (let index = 0; index < left.length; index++) {
+      if (left[index] !== right[index]) return false;
+    }
+    return true;
+  }
+
+  _addToGrid(record) {
+    const grid = record.isStatic ? this.staticGrid : this.dynamicGrid;
+    for (const key of record.cells) {
+      let bucket = grid.get(key);
+      if (!bucket) {
+        bucket = new Set();
+        grid.set(key, bucket);
+      }
+      bucket.add(record);
+    }
+  }
+
+  _removeFromGrid(record) {
+    const grid = record.isStatic ? this.staticGrid : this.dynamicGrid;
+    for (const key of record.cells) {
+      const bucket = grid.get(key);
+      if (!bucket) continue;
+      bucket.delete(record);
+      if (bucket.size === 0) grid.delete(key);
+    }
+  }
+
+  insert(collisionRect, isStatic = !!collisionRect.entity?.isStatic) {
+    const entity = collisionRect.entity;
+    const key = entity && entity.id !== null && entity.id !== undefined
+      ? entity.id
+      : this.anonymousId--;
+    return this._upsert(key, entity, collisionRect, isStatic);
+  }
+
+  upsertEntity(entity) {
+    if (!entity || entity.removed || !entity.shape) return null;
+    return this._upsert(entity.id, entity, entity.shape.boundary, !!entity.isStatic);
+  }
+
+  _upsert(key, entity, boundary, isStatic) {
+    if (!boundary || !rectangleRectangle(this.boundary, boundary)) {
+      this.remove(key);
+      return null;
+    }
+
+    const cells = this._cellKeys(boundary);
+    let record = this.records.get(key);
+    if (!record) {
+      record = {
+        key,
+        entity,
+        x: boundary.x,
+        y: boundary.y,
+        width: boundary.width,
+        height: boundary.height,
+        isStatic,
+        cells,
+        queryGeneration: 0,
+      };
+      this.records.set(key, record);
+      this._addToGrid(record);
+      return record;
+    }
+
+    const membershipChanged = record.isStatic !== isStatic || !this._sameKeys(record.cells, cells);
+    if (membershipChanged) this._removeFromGrid(record);
+    record.entity = entity;
+    record.x = boundary.x;
+    record.y = boundary.y;
+    record.width = boundary.width;
+    record.height = boundary.height;
+    record.isStatic = isStatic;
+    record.cells = cells;
+    if (membershipChanged) this._addToGrid(record);
+    return record;
+  }
+
+  sync(entities) {
+    const seen = new Set();
+    for (const entity of entities.values()) {
+      if (!entity || entity.removed || !entity.shape) continue;
+      seen.add(entity.id);
+      this.upsertEntity(entity);
+    }
+    for (const key of this.records.keys()) {
+      if (!seen.has(key)) this.remove(key);
+    }
+  }
+
+  remove(entityOrId) {
+    const key = typeof entityOrId === 'object' ? entityOrId?.id : entityOrId;
+    const record = this.records.get(key);
+    if (!record) return false;
+    this._removeFromGrid(record);
+    this.records.delete(key);
+    return true;
+  }
+
+  get(rectangle) {
+    if (!rectangle || !rectangleRectangle(this.boundary, rectangle)) return [];
+    const generation = ++this.queryGeneration;
+    const results = [];
+    const keys = this._cellKeys(rectangle);
+
+    const collect = (grid) => {
+      for (const key of keys) {
+        const bucket = grid.get(key);
+        if (!bucket) continue;
+        for (const record of bucket) {
+          if (record.queryGeneration === generation) continue;
+          record.queryGeneration = generation;
+          if (rectangleRectangle(record, rectangle)) results.push(record);
+        }
+      }
+    };
+
+    collect(this.staticGrid);
+    collect(this.dynamicGrid);
+    results.sort((left, right) => {
+      const leftId = left.entity?.id ?? left.key;
+      const rightId = right.entity?.id ?? right.key;
+      return leftId - rightId;
+    });
+    return results;
+  }
+
+  query(rectangle) {
+    return this.get(rectangle);
+  }
+
+  clear() {
+    this.staticGrid.clear();
+    this.dynamicGrid.clear();
+    this.records.clear();
+  }
+}
+
+module.exports = WorldIndex;

--- a/server/src/game/components/ZombieBrain.js
+++ b/server/src/game/components/ZombieBrain.js
@@ -1,0 +1,188 @@
+const Types = require('../Types');
+
+const DECISION_INTERVAL = 0.2;
+const AWARENESS = 2200;
+const SOLIDS = new Set([
+  Types.Entity.House1, Types.Entity.Rock, Types.Entity.MossyRock,
+  Types.Entity.LavaRock, Types.Entity.IceSpike, Types.Entity.Ore,
+  Types.Entity.Cactus,
+]);
+const PROJECTILES = new Set([
+  Types.Entity.Sword, Types.Entity.ThrownSword, Types.Entity.Fireball,
+  Types.Entity.Boulder, Types.Entity.SwordProj, Types.Entity.Snowball,
+  Types.Entity.SandBall,
+]);
+
+function position(entity) {
+  return entity?.shape?.center || entity?.shape || { x: 0, y: 0 };
+}
+
+function velocity(entity) {
+  if (entity?.velocity) return entity.velocity;
+  return { x: entity?.movedDistance?.x || 0, y: entity?.movedDistance?.y || 0 };
+}
+
+function distanceSquared(a, b) {
+  const pa = position(a), pb = position(b);
+  const dx = pb.x - pa.x, dy = pb.y - pa.y;
+  return dx * dx + dy * dy;
+}
+
+class ZombieBrain {
+  constructor(zombie) {
+    this.zombie = zombie;
+    this.target = null;
+    this.retreating = false;
+    this.strafeSign = 1;
+    this.decisionClock = 0;
+    this.throwCooldown = 0;
+    this.attackCooldown = 0;
+    this.moveAngle = 0;
+    this.aimAngle = 0;
+  }
+
+  update(dt) {
+    const z = this.zombie;
+    this.throwCooldown = Math.max(0, this.throwCooldown - dt);
+    this.attackCooldown = Math.max(0, this.attackCooldown - dt);
+    this.decisionClock += dt;
+
+    const stagger = ((z.id || 0) % 5) * (DECISION_INTERVAL / 5);
+    if (!this._staggered) {
+      this._staggered = true;
+      this.decisionClock = stagger;
+    }
+    if (this.decisionClock >= DECISION_INTERVAL) {
+      this.decisionClock %= DECISION_INTERVAL;
+      this.decide();
+    }
+
+    z.inputs.inputUp(Types.Input.SwordSwing);
+    z.inputs.inputUp(Types.Input.SwordThrow);
+    z.mouse = { angle: this.moveAngle, force: 150 };
+    z.angle = this.aimAngle;
+
+    if (!this.target || this.target.removed || this.target.inSafezone) return;
+    const d2 = distanceSquared(z, this.target);
+    const meleeReach = z.shape.radius + z.sword.size * 2.45;
+    if (!this.retreating && d2 <= meleeReach * meleeReach && this.attackCooldown <= 0) {
+      z.inputs.inputDown(Types.Input.SwordSwing);
+      this.attackCooldown = z.variant === 3 ? 0.65 : 0.42;
+    } else if (!this.retreating && d2 > 550 * 550 && d2 < 1850 * 1850 && this.throwCooldown <= 0) {
+      z.inputs.inputDown(Types.Input.SwordThrow);
+      this.throwCooldown = z.variant === 2 ? 3.2 : (z.variant === 3 ? 5.2 : 4.1);
+    }
+  }
+
+  decide() {
+    const z = this.zombie;
+    if (z.health.percent < 0.25) this.retreating = true;
+    else if (z.health.percent > 0.35) this.retreating = false;
+
+    this.target = this.chooseTarget();
+    if (!this.target) {
+      this.moveAngle = ((z.id || 1) * 2.399963 + Date.now() / 9000) % (Math.PI * 2);
+      this.aimAngle = this.moveAngle;
+      return;
+    }
+
+    const zp = position(z), tp = position(this.target);
+    const dx = tp.x - zp.x, dy = tp.y - zp.y;
+    const dist = Math.max(1, Math.hypot(dx, dy));
+    const direct = Math.atan2(dy, dx);
+    const targetVelocity = velocity(this.target);
+    const leadTime = Math.min(0.65, dist / Math.max(1, z.sword.flySpeed.value));
+    this.aimAngle = Math.atan2(
+      tp.y + targetVelocity.y * leadTime - zp.y,
+      tp.x + targetVelocity.x * leadTime - zp.x,
+    );
+
+    const dodge = this.projectileDodge();
+    if (dodge !== null) {
+      this.moveAngle = dodge;
+      return;
+    }
+
+    if (this.retreating) {
+      this.moveAngle = direct + Math.PI + this.spacingBias();
+      return;
+    }
+
+    const ideal = z.variant === 2 ? 620 : (z.variant === 3 ? 480 : 390);
+    const radial = dist > ideal + 130 ? 0 : (dist < ideal - 110 ? Math.PI : Math.PI / 2 * this.strafeSign);
+    this.moveAngle = direct + radial + this.spacingBias();
+    if (this.blockedAhead(this.moveAngle)) {
+      this.strafeSign *= -1;
+      this.moveAngle = direct + Math.PI / 2 * this.strafeSign;
+    }
+  }
+
+  chooseTarget() {
+    let best = null, bestDistance = Infinity;
+    for (const player of this.zombie.game.players) {
+      if (!player || player.removed || player.isBot || player.type !== Types.Entity.Player || player.inSafezone) continue;
+      const d2 = distanceSquared(this.zombie, player);
+      if (d2 < bestDistance) {
+        bestDistance = d2;
+        best = player;
+      }
+    }
+    return best;
+  }
+
+  nearby(radius) {
+    const p = position(this.zombie);
+    const rect = { x: p.x - radius, y: p.y - radius, width: radius * 2, height: radius * 2 };
+    return this.zombie.game.entitiesQuadtree?.get(rect) || [];
+  }
+
+  projectileDodge() {
+    const z = this.zombie, zp = position(z);
+    for (const item of this.nearby(800)) {
+      const p = item.entity;
+      if (!p || p.removed || !PROJECTILES.has(p.type) || p.player === z) continue;
+      if (p.type === Types.Entity.Sword && !p.isFlying) continue;
+      const pp = position(p), pv = velocity(p);
+      const speed2 = pv.x * pv.x + pv.y * pv.y;
+      if (speed2 < 1) continue;
+      const rx = zp.x - pp.x, ry = zp.y - pp.y;
+      const time = Math.max(0, Math.min(0.85, (rx * pv.x + ry * pv.y) / speed2));
+      const miss = Math.hypot(pp.x + pv.x * time - zp.x, pp.y + pv.y * time - zp.y);
+      if (time > 0.02 && miss < z.shape.radius + 135) {
+        const projectileAngle = Math.atan2(pv.y, pv.x);
+        return projectileAngle + Math.PI / 2 * this.strafeSign;
+      }
+    }
+    return null;
+  }
+
+  spacingBias() {
+    const z = this.zombie, zp = position(z);
+    let sx = 0, sy = 0;
+    for (const item of this.nearby(260)) {
+      const other = item.entity;
+      if (!other || other === z || other.type !== Types.Entity.Zombie) continue;
+      const op = position(other), dx = zp.x - op.x, dy = zp.y - op.y;
+      const d2 = Math.max(1, dx * dx + dy * dy);
+      sx += dx / d2;
+      sy += dy / d2;
+    }
+    return (sx || sy) ? Math.atan2(sy, sx) * 0.18 : 0;
+  }
+
+  blockedAhead(angle) {
+    const z = this.zombie, zp = position(z);
+    const aheadX = zp.x + Math.cos(angle) * 210;
+    const aheadY = zp.y + Math.sin(angle) * 210;
+    for (const item of this.nearby(320)) {
+      const e = item.entity;
+      if (!e || !SOLIDS.has(e.type) || !e.shape?.boundary) continue;
+      const b = e.shape.boundary;
+      if (aheadX >= b.x - z.shape.radius && aheadX <= b.x + b.width + z.shape.radius
+        && aheadY >= b.y - z.shape.radius && aheadY <= b.y + b.height + z.shape.radius) return true;
+    }
+    return false;
+  }
+}
+
+module.exports = ZombieBrain;

--- a/server/src/game/entities/Player.js
+++ b/server/src/game/entities/Player.js
@@ -20,6 +20,7 @@ const Timer = require('../components/Timer');
 const EvolutionSystem = require('../evolutions');
 const UpgradeSystem = require('../upgrades');
 const CardSystem = require('../components/CardSystem');
+const DashSystem = require('../components/DashSystem');
 const Types = require('../Types');
 const config = require('../../config');
 const { clamp, calculateGemsXP, filterChatMessage } = require('../../helpers');
@@ -70,6 +71,8 @@ class Player extends Entity {
     this.movementDirection = 0;
     this.angle = 0;
     this.inputs = new Inputs();
+    this.dash = new DashSystem(this);
+    this.inputs.onDirectionInput = inputType => this.dash.onDirectionInput(inputType);
     this.lastDirectionInput = 3; // down
     this.mouse = null;
     this.targets.add(Types.Entity.Player);
@@ -89,6 +92,10 @@ class Player extends Entity {
 
     this.startTimestamp = Date.now();
     this.kills = 0;
+    this.assists = 0;
+    this.killStreak = 0;
+    this.bounty = 0;
+    this.lastKilledByKey = null;
     this.biome = 0;
     this.inSafezone = true;
 
@@ -126,6 +133,8 @@ class Player extends Entity {
 
     this.chatMessage = '';
     this.chatMessageTimer = new Timer(0, 3);
+    this.lastChatAt = 0;
+    this.lastCommandAt = 0;
 
     this.combatLog = new Map();
 
@@ -255,6 +264,7 @@ class Player extends Entity {
 
     this.effects.forEach(effect => effect.update(dt));
     this.upgrades.update(dt);
+    this.dash.update(dt);
     if (this._blindUntil && Date.now() < this._blindUntil) {
       this.flags.set(Types.Flags.Blinded, 1);
     }
@@ -496,6 +506,12 @@ class Player extends Entity {
       }
     }
 
+    if (this.modifiers.dashDirection !== undefined) {
+      this.movementDirection = this.modifiers.dashDirection;
+      dx = speed * Math.cos(this.movementDirection);
+      dy = speed * Math.sin(this.movementDirection);
+    }
+
     if (isNaN(this.velocity.x) || isNaN(this.velocity.y)) {
       console.error(`[VELOCITY_NAN] Player "${this.name}" (id=${this.id}) velocity is NaN! vx=${this.velocity.x}, vy=${this.velocity.y}, pos=(${this.shape.x},${this.shape.y}), effects=[${[...this.effects.keys()]}]`);
       this.velocity.x = 0;
@@ -573,6 +589,8 @@ class Player extends Entity {
       return;
     }
 
+    if (damage > 0 && entity && entity.type === Types.Entity.Player) this.dash.interrupt();
+
 
     if (entity && entity.type === Types.Entity.Player && !this.isBot && !entity.isBot) {
       if (!this.combatLog.has(entity.id)) {
@@ -586,6 +604,7 @@ class Player extends Entity {
       entity.combatLog.get(this.id).damageDealt += damage;
     }
 
+    let appliedDamage = 0;
     if (this.name !== "Update Testing Account") {
       let source = 'map';
       if (entity && entity.type === Types.Entity.Player) {
@@ -593,7 +612,11 @@ class Player extends Entity {
       } else if (entity && Types.Groups.Mobs.includes(entity.type)) {
         source = 'mob';
       }
-      this.health.damaged(damage, { source });
+      appliedDamage = this.health.damaged(damage, { source });
+    }
+
+    if (appliedDamage > 0 && entity && entity.type === Types.Entity.Player) {
+      this.game.combatDirector.recordDamage(this, entity, appliedDamage);
     }
 
     if (this.cards.isTutorial && this.health.isDead) {
@@ -650,6 +673,11 @@ class Player extends Entity {
             entity.cards.onKill(this);
           } catch (e) { /* */ }
           try {
+            this.game.combatDirector.handleKill(this, entity);
+          } catch (e) {
+            console.error('[COMBAT_DIRECTOR] Failed to resolve kill rewards:', e);
+          }
+          try {
             this.flags.set(Types.Flags.PlayerDeath, true);
           } catch (e) { /* */ }
         }
@@ -685,9 +713,14 @@ class Player extends Entity {
   }
 
   addChatMessage(message) {
-    if (message.length === '') return;
+    if (typeof message !== 'string') return;
 
-    const originalMessage = message.slice(0, 60);
+    const now = Date.now();
+    if (now - this.lastChatAt < 750) return;
+    this.lastChatAt = now;
+
+    const originalMessage = message.trim().slice(0, 60);
+    if (originalMessage.length === 0) return;
     const result = filterChatMessage(originalMessage, filter);
     this.chatMessage = result.filtered;
     this.chatMessageTimer.renew();
@@ -695,6 +728,11 @@ class Player extends Entity {
     if (result.matched.length > 0) {
       this.logSwearingIncident(originalMessage, result.matched);
     }
+  }
+
+  setSystemMessage(message) {
+    this.chatMessage = String(message || '').slice(0, 60);
+    this.chatMessageTimer.renew();
   }
 
   logSwearingIncident(message, matchedWords) {
@@ -720,6 +758,7 @@ class Player extends Entity {
 
   remove(message = 'Server', type = Types.DisconnectReason.Server) {
     if (this.client) {
+      this.client.lastKilledByKey = this.lastKilledByKey;
       this.client.disconnectReason = {
         message: message,
         type: type
@@ -744,6 +783,7 @@ class Player extends Entity {
           x: this.shape.x,
           y: this.shape.y,
           killerName: (this.killerEntity && this.killerEntity.type === Types.Entity.Player) ? this.killerEntity.name : null,
+          killerIdentity: this.lastKilledByKey,
           expiresAt: Date.now() + 120000,
           carryKills: this.kills,
           carryPlaytime: this.playtime,
@@ -763,6 +803,7 @@ class Player extends Entity {
           x: this.shape.x,
           y: this.shape.y,
           killerName: (this.killerEntity && this.killerEntity.type === Types.Entity.Player) ? this.killerEntity.name : null,
+          killerIdentity: this.lastKilledByKey,
           expiresAt: Date.now() + 120000,
         };
       }

--- a/server/src/game/entities/Player.js
+++ b/server/src/game/entities/Player.js
@@ -164,6 +164,7 @@ class Player extends Entity {
     state.previousLevelCoins = this.levels.previousLevelCoins;
     state.upgradePoints = this.levels.upgradePoints;
     state.skin = this.skin;
+    state.valorCrests = Number(this.client?.account?.valorCrests) || 0;
 
     state.buffs = structuredClone(this.levels.buffs);
 
@@ -819,7 +820,7 @@ class Player extends Entity {
 
     super.remove();
 
-    if (this.name !== "Update Testing Account" && !this.cards.isTutorial) {
+    if (this.shouldDropCurrencyOnRemove() && this.name !== "Update Testing Account" && !this.cards.isTutorial) {
       let dropAmount = this.calculateDropAmount();
       if (this.client && this.client.insuranceUsed && this.cards.hasMajor(130)) {
         const keptGold = Math.round(this.levels.coins * 0.40);
@@ -827,6 +828,10 @@ class Player extends Entity {
       }
       this.game.map.spawnCoinsInShape(this.shape, dropAmount, this.client?.account?.id);
     }
+  }
+
+  shouldDropCurrencyOnRemove() {
+    return true;
   }
 
   calculateDropAmount() {

--- a/server/src/game/entities/Zombie.js
+++ b/server/src/game/entities/Zombie.js
@@ -1,0 +1,64 @@
+const Player = require('./Player');
+const ZombieBrain = require('../components/ZombieBrain');
+const Types = require('../Types');
+
+const VARIANTS = {
+  1: { name: 'Real Zombie', health: 45, damage: 5, speed: 750, radius: 64 },
+  2: { name: 'Nightlurker', health: 60, damage: 7, speed: 1050, radius: 68 },
+  3: { name: 'Bone Dragon', health: 220, damage: 11, speed: 800, radius: 105 },
+};
+
+class Zombie extends Player {
+  constructor(game, variant = 1, outbreakId = '') {
+    const definition = VARIANTS[variant] || VARIANTS[1];
+    super(game, definition.name);
+    this.type = Types.Entity.Zombie;
+    this.variant = variant;
+    this.skin = variant;
+    this.sword.skin = variant;
+    this.isGlobal = false;
+    this.isBot = true;
+    this.isEventZombie = true;
+    this.outbreakId = outbreakId;
+    this.respawnable = false;
+    this.shape.scaleRadius.baseValue = definition.radius;
+    this.shape.collisionPoly.r = definition.radius;
+    this.speed.baseValue = definition.speed;
+    this.health.max.baseValue = definition.health;
+    this.health.regen.baseValue = 0;
+    this.sword.damage.baseValue = definition.damage;
+    this.sword.targets.delete(Types.Entity.Zombie);
+    this.sword.flyCooldown.baseValue = variant === 2 ? 3.2 : (variant === 3 ? 5.2 : 4.1);
+    this.brain = new ZombieBrain(this);
+  }
+
+  createState() {
+    const state = super.createState();
+    state.account = null;
+    state.valorCrests = 0;
+    return state;
+  }
+
+  applyInputs(dt) {
+    this.brain.update(dt);
+    super.applyInputs(dt);
+  }
+
+  damaged(damage, entity = null, isThrown = false, opts = null) {
+    const before = this.health.percent * this.health.max.value;
+    const alive = !this.removed;
+    super.damaged(damage, entity, isThrown, opts);
+    const after = this.health.percent * this.health.max.value;
+    const applied = Math.max(0, before - after);
+    if (applied > 0 && entity?.type === Types.Entity.Player && !entity.isBot) {
+      this.game.worldEventDirector?.recordContribution(entity, applied, alive && this.removed);
+    }
+  }
+
+  shouldDropCurrencyOnRemove() {
+    return false;
+  }
+}
+
+Zombie.VARIANTS = VARIANTS;
+module.exports = Zombie;

--- a/server/src/index.js
+++ b/server/src/index.js
@@ -92,6 +92,7 @@ function start() {
         entityCnt: game.entities.size,
         playerCnt: game.players.size,
         realPlayersCnt: [...game.players.values()].filter(p => !p.isBot).length,
+        performance: server.performanceMetrics.snapshot(),
       }));
     } catch (err) {
       console.error('[ERROR] /serverinfo error:', err);
@@ -133,7 +134,8 @@ function start() {
 
   function stop(reason) {
     try {
-    console.log('Stopping game...', reason);
+      server.performanceMetrics.close();
+      console.log('Stopping game...', reason);
     for (const client of server.clients.values()) {
       console.log(`Disconnecting client ${client.id}`);
       if (client.player) {

--- a/server/src/metrics/PerformanceMetrics.js
+++ b/server/src/metrics/PerformanceMetrics.js
@@ -1,0 +1,184 @@
+const { monitorEventLoopDelay, performance } = require('node:perf_hooks');
+
+const NANOSECONDS_PER_MILLISECOND = 1e6;
+
+function createAggregate() {
+  return {
+    count: 0,
+    total: 0,
+    last: 0,
+    max: 0,
+  };
+}
+
+function addSample(aggregate, value) {
+  if (!Number.isFinite(value) || value < 0) return;
+  aggregate.count += 1;
+  aggregate.total += value;
+  aggregate.last = value;
+  if (value > aggregate.max) aggregate.max = value;
+}
+
+function round(value, digits = 3) {
+  if (!Number.isFinite(value)) return 0;
+  const factor = 10 ** digits;
+  return Math.round(value * factor) / factor;
+}
+
+function summarizeTiming(aggregate) {
+  return {
+    count: aggregate.count,
+    lastMs: round(aggregate.last),
+    meanMs: round(aggregate.count === 0 ? 0 : aggregate.total / aggregate.count),
+    maxMs: round(aggregate.max),
+  };
+}
+
+function summarizePacketAggregate(aggregate) {
+  return {
+    count: aggregate.count,
+    lastBytes: aggregate.last,
+    meanBytes: Math.round(aggregate.count === 0 ? 0 : aggregate.total / aggregate.count),
+    maxBytes: aggregate.max,
+    totalBytes: aggregate.total,
+  };
+}
+
+function nanosecondsToMilliseconds(value) {
+  // An empty event-loop histogram reports an extremely large sentinel as min.
+  if (!Number.isFinite(value) || value < 0 || value > 1e15) return 0;
+  return round(value / NANOSECONDS_PER_MILLISECOND);
+}
+
+class PerformanceMetrics {
+  constructor(options = {}) {
+    this.now = options.now || (() => performance.now());
+    this.memoryUsage = options.memoryUsage || (() => process.memoryUsage());
+    this.systemSampleIntervalMs = options.systemSampleIntervalMs || 1000;
+    this.startedAt = this.now();
+    this.lastSystemSampleAt = Number.NEGATIVE_INFINITY;
+
+    this.tick = createAggregate();
+    this.phases = new Map();
+    this.packets = createAggregate();
+    this.packetKinds = new Map();
+    this.droppedPackets = 0;
+
+    this.eventLoop = {
+      minMs: 0,
+      maxMs: 0,
+      meanMs: 0,
+      p50Ms: 0,
+      p95Ms: 0,
+      p99Ms: 0,
+    };
+    this.memory = {
+      rssBytes: 0,
+      heapTotalBytes: 0,
+      heapUsedBytes: 0,
+      externalBytes: 0,
+      arrayBuffersBytes: 0,
+    };
+
+    this.eventLoopMonitor = options.eventLoopMonitor
+      || monitorEventLoopDelay({ resolution: options.eventLoopResolutionMs || 20 });
+    if (this.eventLoopMonitor && typeof this.eventLoopMonitor.enable === 'function') {
+      this.eventLoopMonitor.enable();
+    }
+    this.sampleSystem(true);
+  }
+
+  recordPhase(name, durationMs) {
+    let aggregate = this.phases.get(name);
+    if (!aggregate) {
+      aggregate = createAggregate();
+      this.phases.set(name, aggregate);
+    }
+    addSample(aggregate, durationMs);
+  }
+
+  recordTick(durationMs) {
+    addSample(this.tick, durationMs);
+    this.sampleSystem(false);
+  }
+
+  recordPacket(byteLength, options = {}) {
+    if (!Number.isFinite(byteLength) || byteLength < 0) return;
+    addSample(this.packets, byteLength);
+
+    const kind = options.kind || 'other';
+    let aggregate = this.packetKinds.get(kind);
+    if (!aggregate) {
+      aggregate = createAggregate();
+      this.packetKinds.set(kind, aggregate);
+    }
+    addSample(aggregate, byteLength);
+    if (options.dropped) this.droppedPackets += 1;
+  }
+
+  sampleSystem(force = false) {
+    const sampledAt = this.now();
+    if (!force && sampledAt - this.lastSystemSampleAt < this.systemSampleIntervalMs) return;
+    this.lastSystemSampleAt = sampledAt;
+
+    const memory = this.memoryUsage();
+    this.memory = {
+      rssBytes: memory.rss || 0,
+      heapTotalBytes: memory.heapTotal || 0,
+      heapUsedBytes: memory.heapUsed || 0,
+      externalBytes: memory.external || 0,
+      arrayBuffersBytes: memory.arrayBuffers || 0,
+    };
+
+    const histogram = this.eventLoopMonitor;
+    if (!histogram) return;
+    const percentile = (value) => (
+      typeof histogram.percentile === 'function' ? histogram.percentile(value) : 0
+    );
+    this.eventLoop = {
+      minMs: nanosecondsToMilliseconds(histogram.min),
+      maxMs: nanosecondsToMilliseconds(histogram.max),
+      meanMs: nanosecondsToMilliseconds(histogram.mean),
+      p50Ms: nanosecondsToMilliseconds(percentile(50)),
+      p95Ms: nanosecondsToMilliseconds(percentile(95)),
+      p99Ms: nanosecondsToMilliseconds(percentile(99)),
+    };
+    if (typeof histogram.reset === 'function') histogram.reset();
+  }
+
+  snapshot() {
+    this.sampleSystem(false);
+    const phases = {};
+    for (const [name, aggregate] of this.phases) {
+      phases[name] = summarizeTiming(aggregate);
+    }
+
+    const byKind = {};
+    for (const [name, aggregate] of this.packetKinds) {
+      byKind[name] = summarizePacketAggregate(aggregate);
+    }
+
+    return {
+      uptimeSeconds: round((this.now() - this.startedAt) / 1000),
+      tick: {
+        ...summarizeTiming(this.tick),
+        phases,
+      },
+      packets: {
+        ...summarizePacketAggregate(this.packets),
+        droppedPackets: this.droppedPackets,
+        byKind,
+      },
+      eventLoopDelay: { ...this.eventLoop },
+      memory: { ...this.memory },
+    };
+  }
+
+  close() {
+    if (this.eventLoopMonitor && typeof this.eventLoopMonitor.disable === 'function') {
+      this.eventLoopMonitor.disable();
+    }
+  }
+}
+
+module.exports = PerformanceMetrics;

--- a/server/src/network/Client.js
+++ b/server/src/network/Client.js
@@ -114,9 +114,22 @@ class Client {
 
   send(data) {
     if (!data) return;
+    const metrics = this.server && this.server.performanceMetrics;
+    const encodeStartedAt = metrics ? metrics.now() : 0;
     const packet = Protocol.encode(data);
+    const encodeMs = metrics ? metrics.now() - encodeStartedAt : 0;
+    let socketSendMs = 0;
     if (!this.isSocketClosed) {
+      const sendStartedAt = metrics ? metrics.now() : 0;
       const result = this.socket.send(packet, true, true);
+      socketSendMs = metrics ? metrics.now() - sendStartedAt : 0;
+      if (metrics) {
+        const kind = data.fullSync ? 'fullSync' : (data.isPong ? 'control' : 'delta');
+        metrics.recordPacket(packet.byteLength, {
+          kind,
+          dropped: result === 2,
+        });
+      }
       if (result === 2) {
         this.droppedPayloads = (this.droppedPayloads || 0) + 1;
         if (this.droppedPayloads % 100 === 0) {
@@ -126,6 +139,7 @@ class Client {
         this.droppedPayloads = 0;
       }
     }
+    return { packetBytes: packet.byteLength, encodeMs, socketSendMs };
   }
 
   update(dt) {

--- a/server/src/network/Client.js
+++ b/server/src/network/Client.js
@@ -36,12 +36,13 @@ class Client {
       type: 0
     }
     this.pendingRespawn = null;
+    this.lastKilledByKey = null;
 
     // Rate limiting
     this.messageCount = 0;
-    this.messageResetTimer = 0;
-    this.maxMessagesPerSecond = 500; 
-    this.maxQueueSize = 250;
+    this.messageWindowStartedAt = Date.now();
+    this.maxMessagesPerSecond = 180;
+    this.maxQueueSize = 90;
 
     this.lastPlayTime = 0;
     this.playCount = 0;
@@ -55,6 +56,12 @@ class Client {
   }
 
   addMessage(message) {
+    const now = Date.now();
+    if (now - this.messageWindowStartedAt >= 1000) {
+      this.messageCount = 0;
+      this.messageWindowStartedAt = now;
+    }
+
     // Rate limiting check
     this.messageCount++;
     if (this.messageCount > this.maxMessagesPerSecond) {
@@ -141,16 +148,9 @@ class Client {
       }
     }
 
-    // Reset rate limit counter every second (60 ticks at 60 TPS)
-    this.messageResetTimer += 1;
-    if (this.messageResetTimer >= 60) {
-      this.messageCount = 0;
-      this.messageResetTimer = 0;
-    }
-
-    // Reset decode error counter every 10 seconds (600 ticks at 60 TPS)
-    this.decodeErrorResetTimer += 1;
-    if (this.decodeErrorResetTimer >= 600) {
+    // Reset malformed-message accounting on wall time, independent of TPS.
+    this.decodeErrorResetTimer += dt;
+    if (this.decodeErrorResetTimer >= 10) {
       this.decodeErrorCount = 0;
       this.decodeErrorResetTimer = 0;
     }

--- a/server/src/network/Server.js
+++ b/server/src/network/Server.js
@@ -4,11 +4,14 @@ const Protocol = require('./protocol/Protocol');
 const Client = require('./Client');
 const { getBannedIps } = require('../moderation');
 const api = require('./api');
+const PerformanceMetrics = require('../metrics/PerformanceMetrics');
 
 class Server {
   constructor(game) {
     this.globalConnectionLimit = 500;
     this.game = game;
+    this.performanceMetrics = new PerformanceMetrics();
+    this.game.performanceMetrics = this.performanceMetrics;
     this.clients = new Map();
     this.disconnectedClients = new Set();
     this.maxConnectionsPerIP = 50;
@@ -172,6 +175,10 @@ class Server {
   }
 
   tick(dt) {
+    const metrics = this.performanceMetrics;
+    const tickStartedAt = metrics.now();
+    let phaseStartedAt = tickStartedAt;
+
     for (const client of this.clients.values()) {
       if (!client.isReady) continue;
 
@@ -190,22 +197,45 @@ class Server {
         console.error(`[TICK] client.update failed for client ${client.id} (${client.ip}):`, err);
       }
     }
+    metrics.recordPhase('clientInput', metrics.now() - phaseStartedAt);
 
+    phaseStartedAt = metrics.now();
     this.game.tick(dt);
+    metrics.recordPhase('simulation', metrics.now() - phaseStartedAt);
 
+    phaseStartedAt = metrics.now();
     for (const client of this.disconnectedClients) {
       this.game.removeClient(client);
       this.clients.delete(client.id);
       this.disconnectedClients.delete(client);
     }
-    Protocol.beginBroadcast();
-    for (const client of this.clients.values()) {
-      const payload = this.game.createPayload(client);
-      client.send(payload);
-    }
+    metrics.recordPhase('disconnectCleanup', metrics.now() - phaseStartedAt);
 
+    phaseStartedAt = metrics.now();
+    Protocol.beginBroadcast();
+    let snapshotBuildMs = 0;
+    let protocolEncodeMs = 0;
+    let socketSendMs = 0;
+    for (const client of this.clients.values()) {
+      const snapshotStartedAt = metrics.now();
+      const payload = this.game.createPayload(client);
+      snapshotBuildMs += metrics.now() - snapshotStartedAt;
+      const sendTiming = client.send(payload);
+      if (sendTiming) {
+        protocolEncodeMs += sendTiming.encodeMs;
+        socketSendMs += sendTiming.socketSendMs;
+      }
+    }
+    metrics.recordPhase('snapshotBuild', snapshotBuildMs);
+    metrics.recordPhase('protocolEncode', protocolEncodeMs);
+    metrics.recordPhase('socketSend', socketSendMs);
+    metrics.recordPhase('replication', metrics.now() - phaseStartedAt);
+
+    phaseStartedAt = metrics.now();
     this.game.endTick();
     this.clients.forEach(client => client.cleanup());
+    metrics.recordPhase('endTickCleanup', metrics.now() - phaseStartedAt);
+    metrics.recordTick(metrics.now() - tickStartedAt);
   }
 }
 

--- a/server/src/network/protocol/schema.proto
+++ b/server/src/network/protocol/schema.proto
@@ -171,6 +171,7 @@ message Entity {
   bool offhandDecreasing = 67;
   int32 activeSelection = 68;
   int32 abilityCharges = 69;
+  int32 valorCrests = 70;
 
   // Sword block
 }

--- a/server/test/client-rate-limit.test.js
+++ b/server/test/client-rate-limit.test.js
@@ -1,0 +1,56 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const Client = require('../src/network/Client');
+
+function createClient() {
+  let closeCount = 0;
+  const socket = {
+    id: 'test-client',
+    ip: '127.0.0.1',
+    close() { closeCount++; },
+    ping() {},
+    send() { return 1; },
+  };
+  const game = { players: new Set(), tps: 20 };
+  const client = new Client(game, socket);
+  return { client, get closeCount() { return closeCount; } };
+}
+
+test('message limits reset on wall time instead of server tick count', () => {
+  const originalNow = Date.now;
+  let now = 1000;
+  Date.now = () => now;
+
+  try {
+    const fixture = createClient();
+    fixture.client.maxMessagesPerSecond = 2;
+    fixture.client.maxQueueSize = 20;
+
+    fixture.client.addMessage({ play: true });
+    fixture.client.addMessage({ play: true });
+    assert.equal(fixture.closeCount, 0);
+
+    fixture.client.addMessage({ play: true });
+    assert.equal(fixture.closeCount, 1);
+
+    now += 1001;
+    fixture.client.addMessage({ play: true });
+    assert.equal(fixture.client.messageCount, 1);
+  } finally {
+    Date.now = originalNow;
+  }
+});
+
+test('queue limits close a flooding client before memory grows unbounded', () => {
+  const fixture = createClient();
+  fixture.client.maxMessagesPerSecond = 1000;
+  fixture.client.maxQueueSize = 2;
+
+  fixture.client.addMessage({ play: true });
+  fixture.client.addMessage({ play: true });
+  fixture.client.addMessage({ play: true });
+
+  assert.equal(fixture.client.messages.length, 2);
+  assert.equal(fixture.closeCount, 1);
+  assert.equal(fixture.client.disconnectReason.message, 'Message queue overflow');
+});

--- a/server/test/combat-director.test.js
+++ b/server/test/combat-director.test.js
@@ -1,0 +1,84 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const Types = require('../src/game/Types');
+const CombatDirector = require('../src/game/components/CombatDirector');
+
+function makePlayer(id, accountId, coins = 0) {
+  const player = {
+    id,
+    type: Types.Entity.Player,
+    removed: false,
+    killStreak: 0,
+    assists: 0,
+    bounty: 0,
+    lastKilledByKey: null,
+    client: { account: { id: accountId }, ip: `10.0.0.${id}` },
+    health: {
+      isDead: false,
+      max: { value: 100 },
+      gained: 0,
+      gain(amount) { this.gained += amount; },
+    },
+    levels: {
+      coins,
+      awarded: 0,
+      addCoins(amount) {
+        this.awarded += amount;
+        this.coins += amount;
+      },
+    },
+    setSystemMessage(message) { this.message = message; },
+    dash: { status: 'ready' },
+    kills: 0,
+  };
+  return player;
+}
+
+test('kills grant streaks, capped bounty rewards, healing, and assists', () => {
+  const killer = makePlayer(1, 101, 1000);
+  const victim = makePlayer(2, 202, 20000);
+  const assistant = makePlayer(3, 303, 500);
+  victim.killStreak = 4;
+
+  const game = { entities: new Map([[1, killer], [2, victim], [3, assistant]]), players: new Set(), maxPlayers: 100 };
+  const director = new CombatDirector(game);
+  director.recordDamage(victim, killer, 70, 1000);
+  director.recordDamage(victim, assistant, 30, 1000);
+
+  const result = director.handleKill(victim, killer, 1500);
+  assert.equal(killer.killStreak, 1);
+  assert.equal(victim.killStreak, 0);
+  assert.ok(result.bountyAward > 0);
+  assert.equal(killer.health.gained, 6);
+  assert.equal(assistant.assists, 1);
+  assert.equal(result.assists.length, 1);
+  assert.ok(assistant.levels.awarded > 0);
+  assert.equal(director.damageLedger.has(victim.id), false);
+});
+
+test('repeat victims rapidly diminish farmable combat rewards', () => {
+  const killer = makePlayer(1, 101, 0);
+  const victim = makePlayer(2, 202, 10000);
+  const game = { entities: new Map([[1, killer], [2, victim]]), players: new Set(), maxPlayers: 100 };
+  const director = new CombatDirector(game);
+
+  const multipliers = [];
+  for (let i = 0; i < 4; i++) {
+    victim.killStreak = 3;
+    multipliers.push(director.handleKill(victim, killer, 1000 + i).repeatMultiplier);
+  }
+  assert.deepEqual(multipliers, [1, 0.55, 0.2, 0]);
+});
+
+test('combat commands expose mechanics without changing UI code', () => {
+  const player = makePlayer(1, 101, 100);
+  player.kills = 5;
+  player.assists = 2;
+  player.killStreak = 3;
+  const game = { entities: new Map([[1, player]]), players: new Set([player]), maxPlayers: 100 };
+  const director = new CombatDirector(game);
+
+  assert.equal(director.handleCommand(player, '/stats'), true);
+  assert.match(player.message, /K 5 A 2 streak 3/);
+  assert.equal(director.handleCommand(player, 'hello'), false);
+});

--- a/server/test/dash-system.test.js
+++ b/server/test/dash-system.test.js
@@ -1,0 +1,48 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const Types = require('../src/game/Types');
+const DashSystem = require('../src/game/components/DashSystem');
+
+function makePlayer() {
+  return {
+    removed: false,
+    inSafezone: false,
+    modifiers: {},
+    cards: { choosingCard: false, instantSelect: false },
+    speed: { multiplier: 1 },
+    movementDirection: 0,
+    hypnotizedBy: null,
+  };
+}
+
+test('a valid double tap activates a directional dash', () => {
+  const player = makePlayer();
+  const dash = new DashSystem(player);
+
+  assert.equal(dash.onDirectionInput(Types.Input.Right, 1000), false);
+  assert.equal(dash.onDirectionInput(Types.Input.Right, 1200), true);
+  dash.update(0.05);
+
+  assert.equal(player.speed.multiplier, DashSystem.DEFAULTS.speedMultiplier);
+  assert.equal(player.modifiers.dashNoclip, true);
+  assert.equal(player.modifiers.dashDirection, 0);
+  assert.equal(dash.status, 'active');
+});
+
+test('dash respects safety, control locks, cooldown, and interruption', () => {
+  const player = makePlayer();
+  const dash = new DashSystem(player);
+
+  player.inSafezone = true;
+  dash.onDirectionInput(Types.Input.Up, 1000);
+  assert.equal(dash.onDirectionInput(Types.Input.Up, 1100), false);
+
+  player.inSafezone = false;
+  dash.onDirectionInput(Types.Input.Up, 2000);
+  assert.equal(dash.onDirectionInput(Types.Input.Up, 2100), true);
+  dash.interrupt();
+  assert.notEqual(dash.status, 'active');
+
+  dash.onDirectionInput(Types.Input.Up, 3000);
+  assert.equal(dash.onDirectionInput(Types.Input.Up, 3100), false);
+});

--- a/server/test/health.test.js
+++ b/server/test/health.test.js
@@ -1,0 +1,29 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const Health = require('../src/game/components/Health');
+
+test('damage is finite, positive, and capped at remaining health', () => {
+  const health = new Health(100, 5, 0);
+  assert.equal(health.damaged(-20), 0);
+  assert.equal(health.damaged(Number.NaN), 0);
+  assert.equal(health.damaged(30), 30);
+  assert.equal(health.percent, 0.7);
+  assert.equal(health.damaged(500), 70);
+  assert.equal(health.percent, 0);
+  assert.equal(health.isDead, true);
+  assert.equal(health.damaged(10), 0);
+});
+
+test('healing cannot revive a dead entity and regeneration stays bounded', () => {
+  const health = new Health(100, 10, 0);
+  health.damaged(50);
+  health.regenWaitUntil = 0;
+  health.update(2);
+  assert.equal(health.percent, 0.7);
+  assert.ok(Math.abs(health.gain(1000) - 30) < 1e-9);
+  assert.equal(health.percent, 1);
+
+  health.damaged(100);
+  assert.equal(health.gain(50), 0);
+  assert.equal(health.percent, 0);
+});

--- a/server/test/input-sanitizer.test.js
+++ b/server/test/input-sanitizer.test.js
@@ -1,0 +1,40 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const Types = require('../src/game/Types');
+const {
+  MAX_INPUT_EVENTS,
+  MAX_MOUSE_FORCE,
+  normalizeAngle,
+  sanitizeInputEvents,
+  sanitizeMouse,
+} = require('../src/game/components/InputSanitizer');
+
+test('normalizeAngle accepts zero and wraps extreme angles', () => {
+  assert.equal(normalizeAngle(0), 0);
+  assert.ok(Math.abs(normalizeAngle(Math.PI * 5) - Math.PI) < 1e-9);
+  assert.equal(normalizeAngle(Number.NaN), null);
+  assert.equal(normalizeAngle(Infinity), null);
+});
+
+test('sanitizeInputEvents rejects unknown inputs and caps each packet', () => {
+  const events = [
+    { inputType: Types.Input.Up, inputDown: true },
+    { inputType: 999, inputDown: true },
+    { inputType: Types.Input.SwordSwing, inputDown: 'yes' },
+    ...Array.from({ length: 30 }, () => ({ inputType: Types.Input.Left, inputDown: true })),
+  ];
+
+  const sanitized = sanitizeInputEvents(events);
+  assert.equal(sanitized.length, MAX_INPUT_EVENTS - 1);
+  assert.deepEqual(sanitized[0], { inputType: Types.Input.Up, inputDown: true });
+  assert.deepEqual(sanitized[1], { inputType: Types.Input.SwordSwing, inputDown: false });
+});
+
+test('sanitizeMouse clamps force and rejects malformed coordinates', () => {
+  assert.deepEqual(sanitizeMouse({ angle: 0, force: 999 }), {
+    angle: 0,
+    force: MAX_MOUSE_FORCE,
+  });
+  assert.equal(sanitizeMouse({ angle: 'nope', force: 10 }), null);
+  assert.equal(sanitizeMouse({ angle: 1, force: Infinity }), null);
+});

--- a/server/test/performance-benchmarks.test.js
+++ b/server/test/performance-benchmarks.test.js
@@ -23,9 +23,9 @@ test('collision fixture produces a deterministic candidate and hit signature', (
   assert.equal(second.candidateCount, first.candidateCount);
   assert.equal(second.exactHitCount, first.exactHitCount);
   assert.equal(second.checksum, first.checksum);
-  assert.equal(first.candidateCount, 2228);
+  assert.equal(first.candidateCount, first.exactHitCount);
   assert.equal(first.exactHitCount, 787);
-  assert.equal(first.checksum, 3569105845);
+  assert.equal(first.checksum, 880840297);
   assert.ok(first.exactHitCount > 0);
 });
 

--- a/server/test/performance-benchmarks.test.js
+++ b/server/test/performance-benchmarks.test.js
@@ -1,0 +1,47 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const {
+  createCollisionFixture,
+  executeCollisionPass,
+} = require('../bench/collision.bench');
+const {
+  createSnapshotFixtures,
+  hashBytes,
+} = require('../bench/snapshot.bench');
+const Protocol = require('../src/network/protocol/Protocol');
+
+test('collision fixture produces a deterministic candidate and hit signature', () => {
+  const fixture = createCollisionFixture({
+    seed: 1234,
+    entityCount: 250,
+    queryCount: 100,
+    worldSize: 4000,
+  });
+  const first = executeCollisionPass(fixture);
+  const second = executeCollisionPass(fixture);
+
+  assert.equal(second.candidateCount, first.candidateCount);
+  assert.equal(second.exactHitCount, first.exactHitCount);
+  assert.equal(second.checksum, first.checksum);
+  assert.equal(first.candidateCount, 2228);
+  assert.equal(first.exactHitCount, 787);
+  assert.equal(first.checksum, 3569105845);
+  assert.ok(first.exactHitCount > 0);
+});
+
+test('snapshot fixture encodes to identical bytes on every run', () => {
+  const fixtures = createSnapshotFixtures({
+    seed: 5678,
+    dynamicEntityCount: 40,
+    staticEntityCount: 15,
+    deltaEntityCount: 10,
+  });
+  const first = Protocol.encode(fixtures.full);
+  const second = Protocol.encode(fixtures.full);
+
+  assert.equal(second.byteLength, first.byteLength);
+  assert.equal(hashBytes(second), hashBytes(first));
+  assert.equal(first.byteLength, 6393);
+  assert.equal(hashBytes(first), 1839186294);
+  assert.ok(first.byteLength > 0);
+});

--- a/server/test/performance-metrics.test.js
+++ b/server/test/performance-metrics.test.js
@@ -1,0 +1,54 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const PerformanceMetrics = require('../src/metrics/PerformanceMetrics');
+
+test('performance metrics aggregate tick phases, packet sizes, loop delay, and memory', () => {
+  let now = 0;
+  const monitor = {
+    min: 1e6,
+    max: 9e6,
+    mean: 3e6,
+    enabled: false,
+    resetCount: 0,
+    enable() { this.enabled = true; },
+    disable() { this.enabled = false; },
+    reset() { this.resetCount += 1; },
+    percentile(value) { return value === 50 ? 2e6 : (value === 95 ? 7e6 : 8e6); },
+  };
+  const metrics = new PerformanceMetrics({
+    now: () => now,
+    eventLoopMonitor: monitor,
+    systemSampleIntervalMs: 1000,
+    memoryUsage: () => ({
+      rss: 1000,
+      heapTotal: 800,
+      heapUsed: 500,
+      external: 100,
+      arrayBuffers: 50,
+    }),
+  });
+
+  metrics.recordPhase('simulation', 4);
+  metrics.recordPhase('simulation', 6);
+  metrics.recordTick(12);
+  metrics.recordPacket(120, { kind: 'delta' });
+  metrics.recordPacket(480, { kind: 'fullSync', dropped: true });
+  now = 1500;
+
+  const snapshot = metrics.snapshot();
+  assert.deepEqual(snapshot.tick.phases.simulation, {
+    count: 2,
+    lastMs: 6,
+    meanMs: 5,
+    maxMs: 6,
+  });
+  assert.equal(snapshot.tick.meanMs, 12);
+  assert.equal(snapshot.packets.meanBytes, 300);
+  assert.equal(snapshot.packets.droppedPackets, 1);
+  assert.equal(snapshot.packets.byKind.fullSync.maxBytes, 480);
+  assert.equal(snapshot.eventLoopDelay.p95Ms, 7);
+  assert.equal(snapshot.memory.heapUsedBytes, 500);
+
+  metrics.close();
+  assert.equal(monitor.enabled, false);
+});

--- a/server/test/spectator-full-sync.test.js
+++ b/server/test/spectator-full-sync.test.js
@@ -1,0 +1,59 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const Game = require('../src/game/Game');
+
+function makeEntity(id, isStatic) {
+  return {
+    id,
+    isStatic,
+    type: 1,
+    state: { get: () => ({ id, type: 1 }) },
+  };
+}
+
+function makeGame() {
+  const staticEntity = makeEntity(1, true);
+  const dynamicEntity = makeEntity(2, false);
+  return {
+    entities: new Map([[1, staticEntity], [2, dynamicEntity]]),
+    map: { getData: () => ({ staticObjects: [{ id: 1, type: 1 }] }) },
+    globalEntities: { getAll: () => ({}) },
+    getAllEntities: Game.prototype.getAllEntities,
+  };
+}
+
+test('spectator full sync sends static entities only through mapData', () => {
+  const game = makeGame();
+  const spectator = {
+    id: 99,
+    isSpectating: true,
+    state: { get: () => ({ x: 0, y: 0 }) },
+    getEntitiesInViewport: () => [1, 2],
+  };
+  const client = { spectator, player: null, fullSync: true };
+
+  const payload = Game.prototype.createPayload.call(game, client);
+
+  assert.equal(payload.mapData.staticObjects.length, 1);
+  assert.equal(payload.entities[1], undefined);
+  assert.equal(payload.entities[2].id, 2);
+});
+
+test('player full sync still includes static entities', () => {
+  const game = makeGame();
+  const player = {
+    id: 7,
+    getEntitiesInViewport: () => [1, 2],
+  };
+  const client = {
+    spectator: { isSpectating: false },
+    player,
+    fullSync: true,
+  };
+
+  const payload = Game.prototype.createPayload.call(game, client);
+
+  assert.equal(payload.mapData, undefined);
+  assert.equal(payload.entities[1].id, 1);
+  assert.equal(payload.entities[2].id, 2);
+});

--- a/server/test/world-index.test.js
+++ b/server/test/world-index.test.js
@@ -1,0 +1,93 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const WorldIndex = require('../src/game/components/WorldIndex');
+const { rectangleRectangle } = require('../src/game/collisions');
+
+function entity(id, x, y, width, height, isStatic = false) {
+  return {
+    id,
+    isStatic,
+    removed: false,
+    shape: { get boundary() { return { x, y, width, height }; } },
+    move(nextX, nextY) { x = nextX; y = nextY; },
+  };
+}
+
+test('WorldIndex exactly matches brute force queries in deterministic ID order', () => {
+  const index = new WorldIndex({ x: -2048, y: -2048, width: 4096, height: 4096 }, 512);
+  const entities = new Map();
+  let seed = 123456789;
+  const random = () => {
+    seed = (Math.imul(seed, 1664525) + 1013904223) >>> 0;
+    return seed / 4294967296;
+  };
+  for (let id = 1; id <= 500; id++) {
+    const width = 10 + Math.floor(random() * 900);
+    const height = 10 + Math.floor(random() * 900);
+    const item = entity(
+      id,
+      -2000 + Math.floor(random() * (4000 - width)),
+      -2000 + Math.floor(random() * (4000 - height)),
+      width,
+      height,
+      id % 4 === 0,
+    );
+    entities.set(id, item);
+  }
+  index.sync(entities);
+
+  for (let queryId = 0; queryId < 200; queryId++) {
+    const query = {
+      x: -2100 + Math.floor(random() * 4000),
+      y: -2100 + Math.floor(random() * 4000),
+      width: 1 + Math.floor(random() * 1000),
+      height: 1 + Math.floor(random() * 1000),
+    };
+    const actual = index.get(query).map(result => result.entity.id);
+    const expected = [...entities.values()]
+      .filter(item => rectangleRectangle(item.shape.boundary, query))
+      .map(item => item.id)
+      .sort((left, right) => left - right);
+    assert.deepEqual(actual, expected);
+  }
+});
+
+test('WorldIndex updates movement, static transitions, insertion, and removal', () => {
+  const index = new WorldIndex({ x: 0, y: 0, width: 4096, height: 4096 }, 512);
+  const moving = entity(2, 50, 50, 80, 80);
+  const large = entity(1, 400, 400, 900, 900, true);
+  const entities = new Map([[2, moving], [1, large]]);
+  index.sync(entities);
+
+  assert.deepEqual(index.get({ x: 0, y: 0, width: 600, height: 600 }).map(r => r.entity.id), [1, 2]);
+  moving.move(3000, 3000);
+  moving.isStatic = true;
+  index.sync(entities);
+  assert.deepEqual(index.get({ x: 0, y: 0, width: 200, height: 200 }).map(r => r.entity.id), []);
+  assert.deepEqual(index.get({ x: 2950, y: 2950, width: 200, height: 200 }).map(r => r.entity.id), [2]);
+
+  entities.delete(1);
+  index.sync(entities);
+  assert.equal(index.records.has(1), false);
+  const added = entity(3, 10, 10, 20, 20);
+  entities.set(3, added);
+  index.upsertEntity(added);
+  assert.deepEqual(index.get({ x: 0, y: 0, width: 40, height: 40 }).map(r => r.entity.id), [3]);
+});
+
+test('WorldIndex handles exact cell edges, very large bounds, and removals during result iteration', () => {
+  const index = new WorldIndex({ x: -2048, y: -2048, width: 4096, height: 4096 }, 512);
+  const edgeLeft = entity(9, 0, 0, 512, 512, true);
+  const edgeRight = entity(3, 512, 512, 1, 1);
+  const spanningPolygonBounds = entity(7, -1536, -900, 3072, 1800, true);
+  const entities = new Map([[9, edgeLeft], [3, edgeRight], [7, spanningPolygonBounds]]);
+  index.sync(entities);
+
+  assert.deepEqual(index.get({ x: 512, y: 512, width: 0, height: 0 }).map(r => r.entity.id), [3, 7, 9]);
+  assert.deepEqual(index.get({ x: 1400, y: -10, width: 20, height: 20 }).map(r => r.entity.id), [7]);
+
+  const results = index.get({ x: -2048, y: -2048, width: 4096, height: 4096 });
+  for (const result of results) index.remove(result.entity);
+  assert.equal(index.records.size, 0);
+  assert.deepEqual(index.get({ x: -2048, y: -2048, width: 4096, height: 4096 }), []);
+});

--- a/server/test/zombie-outbreak.test.js
+++ b/server/test/zombie-outbreak.test.js
@@ -1,0 +1,167 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const Game = require('../src/game/Game');
+const Types = require('../src/game/Types');
+const WorldEventDirector = require('../src/game/components/WorldEventDirector');
+
+function player(id, { safe = false, account = id } = {}) {
+  return {
+    id, type: Types.Entity.Player, isBot: false, removed: false, inSafezone: safe,
+    shape: { x: id * 50, y: id * 80 }, cards: { isTutorial: false },
+    client: { id: `client-${id}`, account: account ? { id: account, valorCrests: 0 } : null },
+    messages: [], setSystemMessage(message) { this.messages.push(message); },
+  };
+}
+
+function fixture(random = () => 0) {
+  const game = new Game();
+  game.maxEntities = 1000;
+  game.map.x = -10000;
+  game.map.y = -10000;
+  game.map.width = 20000;
+  game.map.height = 20000;
+  game.map.safezone = null;
+  game.map.tutorialSafezone = null;
+  game.map.aiPlayersCount = 4;
+  game.map.entityTimers.clear();
+  game.players.clear();
+  game.entities.clear();
+  game.newEntities.clear();
+  game.idPool = new (require('../src/game/components/IdPool'))();
+  const director = new WorldEventDirector(game, { random });
+  game.worldEventDirector = director;
+  return { game, director };
+}
+
+test('outbreak warning uses active eligible play and spawns an exact 16/3/1 ring', () => {
+  const { game, director } = fixture();
+  const p = player(7);
+  game.players.add(p);
+  director.update(12 * 60 - 1);
+  assert.equal(director.phase, WorldEventDirector.PHASE.IDLE);
+  director.update(1);
+  assert.equal(director.phase, WorldEventDirector.PHASE.WARNING);
+  director.update(20);
+  assert.equal(director.phase, WorldEventDirector.PHASE.ACTIVE);
+  const zombies = Array.from(game.entities.values()).filter(e => e.type === Types.Entity.Zombie);
+  assert.equal(zombies.length, 20);
+  assert.deepEqual(zombies.reduce((counts, z) => ({ ...counts, [z.variant]: (counts[z.variant] || 0) + 1 }), {}), { 1: 16, 2: 3, 3: 1 });
+  assert.ok(zombies.every(z => Math.abs(Math.hypot(z.shape.x - p.shape.x, z.shape.y - p.shape.y) - 1200) < 1e-6));
+});
+
+test('safe players defer their whole ring, late joins get one, and capacity never truncates', () => {
+  const { game, director } = fixture();
+  const outside = player(1);
+  const sheltered = player(2, { safe: true });
+  game.players.add(outside);
+  game.players.add(sheltered);
+  director.beginOutbreak();
+  assert.equal(director.zombieIds.size, 20);
+  sheltered.inSafezone = false;
+  game.maxEntities = game.entities.size + 39;
+  director.update(0.2);
+  assert.equal(director.zombieIds.size, 20);
+  game.maxEntities += 1;
+  director.update(0.2);
+  assert.equal(director.zombieIds.size, 40);
+  director.update(0.2);
+  assert.equal(director.zombieIds.size, 40);
+
+  const late = player(3);
+  game.players.add(late);
+  game.maxEntities += 40;
+  director.update(0.2);
+  assert.equal(director.zombieIds.size, 60);
+});
+
+test('victory and timeout remove survivors, restore NPC settings, and reschedule', () => {
+  const { game, director } = fixture(() => 0.5);
+  const p = player(1);
+  game.players.add(p);
+  director.beginOutbreak();
+  assert.equal(game.map.aiPlayersCount, 0);
+  for (const id of director.zombieIds) game.removeEntity(game.entities.get(id));
+  director.update(0.1);
+  assert.equal(director.phase, WorldEventDirector.PHASE.IDLE);
+  assert.equal(director.lastResult.success, true);
+  assert.equal(game.map.aiPlayersCount, 4);
+  assert.ok(director.nextAt >= 12 * 60 && director.nextAt <= 18 * 60);
+
+  director.beginOutbreak();
+  director.update(8 * 60);
+  assert.equal(director.lastResult.success, false);
+  assert.equal(Array.from(game.entities.values()).filter(e => e.type === Types.Entity.Zombie).length, 0);
+  assert.equal(game.map.aiPlayersCount, 4);
+});
+
+test('contributions exclude guests and choose a deterministic signed-in MVP', () => {
+  const { game, director } = fixture();
+  const first = player(1, { account: 10 });
+  const second = player(2, { account: 20 });
+  const guest = player(3, { account: null });
+  game.players.add(first); game.players.add(second); game.players.add(guest);
+  director.phase = WorldEventDirector.PHASE.ACTIVE;
+  director.eventId = '11111111-1111-4111-8111-111111111111';
+  director.recordContribution(first, 250, true);
+  director.recordContribution(second, 210, true);
+  director.recordContribution(second, 1, true);
+  director.recordContribution(guest, 500, true);
+  let payload;
+  director.postAwardsWithRetry = value => { payload = value; };
+  director.awardValor(director.eventId);
+  assert.deepEqual(payload.awards, [
+    { accountId: 10, crests: 6, zombieKills: 1, mvp: true },
+    { accountId: 20, crests: 5, zombieKills: 2, mvp: false },
+  ]);
+});
+
+test('death/respawn identity cannot receive a duplicate ring and NPC population is restored', () => {
+  const { game, director } = fixture();
+  const firstLife = player(1, { account: 44 });
+  const bot = { id: 700, type: Types.Entity.Player, isBot: true, removed: false, originalDefinition: { type: Types.Entity.Player, isPlayer: true } };
+  game.players.add(firstLife);
+  game.players.add(bot);
+  game.entities.set(bot.id, bot);
+  let restoredBots = 0;
+  game.map.spawnPlayerBot = () => { restoredBots += 1; };
+  director.beginOutbreak();
+  assert.equal(director.zombieIds.size, 20);
+  assert.equal(game.entities.has(bot.id), false);
+
+  game.players.delete(firstLife);
+  const respawn = player(99, { account: 44 });
+  game.players.add(respawn);
+  director.update(0.2);
+  assert.equal(director.zombieIds.size, 20);
+  director.update(8 * 60);
+  assert.equal(restoredBots, 1);
+});
+
+test('ZombieBrain targets humans, leads throws, dodges trajectories, and uses retreat hysteresis', () => {
+  const { game } = fixture();
+  const Zombie = require('../src/game/entities/Zombie');
+  const z = new Zombie(game, 2, 'test');
+  z.id = 101;
+  z.shape.x = 0; z.shape.y = 0;
+  const human = player(9);
+  human.shape.x = 900; human.shape.y = 0;
+  human.velocity = { x: 0, y: 180 };
+  game.players.add(human);
+  game.entitiesQuadtree = { get: () => [] };
+  z.brain.decide();
+  assert.equal(z.brain.target, human);
+  assert.ok(z.brain.aimAngle > 0);
+  z.health.percent = 0.24;
+  z.brain.decide();
+  assert.equal(z.brain.retreating, true);
+  z.health.percent = 0.30;
+  z.brain.decide();
+  assert.equal(z.brain.retreating, true);
+  z.health.percent = 0.36;
+  z.brain.decide();
+  assert.equal(z.brain.retreating, false);
+
+  const projectile = { type: Types.Entity.ThrownSword, shape: { x: -300, y: 0 }, velocity: { x: 600, y: 0 } };
+  game.entitiesQuadtree = { get: () => [{ entity: projectile }] };
+  assert.ok(Math.abs(Math.abs(z.brain.projectileDodge()) - Math.PI / 2) < 1e-6);
+});


### PR DESCRIPTION
This revamp adds **double-tap dashing, assists, streak bounties, revenge rewards, anti-farming protections, hardened health/input/chat/network handling, detailed tick/packet/event-loop/memory metrics, deterministic collision and snapshot benchmarks, and a 512-unit deterministic spatial grid**; it also introduces **automatic 20-zombie-per-player outbreaks with predictive dedicated AI, dynamic one-twentieth target health and coin scaling, existing undead artwork, green minimap markers, persistent non-spendable Valor Crests and leaderboards, development-only outbreak and coin commands, 3–5-wolf boid packs that retain the original wolf stats, and full-health NPC-player alliances that chat, follow each other, share enemies, and prevent friendly fire, while preserving the existing map data, shop, menus, cosmetics catalogs, and spendable-currency systems**.

The code is under the GPL v3 license that the main branch has, and is owned by the maintainers of the repository.