### PR TITLE
Prevent multiboxing with server-authoritative session locks

### DIFF
--- a/api/src/auth/auth.controller.ts
+++ b/api/src/auth/auth.controller.ts
@@ -1,4 +1,4 @@
-import { Body, Controller, Get, Post, UseGuards, Res, Req, Query, UnauthorizedException } from '@nestjs/common';
+import { Body, ConflictException, Controller, Get, Post, UseGuards, Res, Req, Query, UnauthorizedException } from '@nestjs/common';
 import { Response } from 'express';
 import { Throttle } from '@nestjs/throttler';
 import { RegisterDTO, LoginDTO, SecretLoginDTO } from './auth.dto';
@@ -7,12 +7,14 @@ import { ServerGuard } from './guards/server.guard';
 import { config } from 'src/config';
 import { AccountGuard } from './guards/account.guard';
 import { ClansService } from 'src/clans/clans.service';
+import { GameSessionService } from './game-session.service';
 
 @Controller('auth')
 export class AuthController {
   constructor(
     private readonly authService: AuthService,
     private readonly clansService: ClansService,
+    private readonly gameSessions: GameSessionService,
   ) {}
 
   @Get('username-available')
@@ -85,6 +87,47 @@ export class AuthController {
   async verify(@Req() req) {
     const clan = await this.clansService.getMembershipForAccount(req.account.id);
     return { account: { ...req.account, clan } };
+  }
+
+  @UseGuards(ServerGuard, AccountGuard)
+  @Post('game-session/acquire')
+  async acquireGameSession(@Req() req) {
+    const result = await this.gameSessions.acquire(
+      req.account.id,
+      req.body.serverId,
+      req.body.ownerId,
+    );
+    if ('retryAfterMs' in result) {
+      throw new ConflictException({
+        code: 'GAME_SESSION_ACTIVE',
+        message: 'Account is already active in another game session',
+        retryAfterMs: result.retryAfterMs,
+      });
+    }
+
+    return result;
+  }
+
+  @UseGuards(ServerGuard)
+  @Post('game-session/heartbeat')
+  async heartbeatGameSession(@Body() body: any) {
+    const active = await this.gameSessions.heartbeat(
+      Number(body.accountId),
+      String(body.leaseId || ''),
+      body.serverId,
+    );
+    return { active, ttlMs: GameSessionService.leaseTtlMs };
+  }
+
+  @UseGuards(ServerGuard)
+  @Post('game-session/release')
+  async releaseGameSession(@Body() body: any) {
+    const released = await this.gameSessions.release(
+      Number(body.accountId),
+      String(body.leaseId || ''),
+      body.serverId,
+    );
+    return { released };
   }
 
   @UseGuards(AccountGuard)

--- a/api/src/auth/auth.module.ts
+++ b/api/src/auth/auth.module.ts
@@ -3,13 +3,17 @@ import { AuthService } from './auth.service';
 import { AuthController } from './auth.controller';
 import { AccountsModule } from 'src/accounts/accounts.module';
 import { ClansModule } from 'src/clans/clans.module';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { ActiveGameSession } from './game-session.entity';
+import { GameSessionService } from './game-session.service';
 
 @Module({
   imports: [
     forwardRef(() => AccountsModule),
     forwardRef(() => ClansModule),
+    TypeOrmModule.forFeature([ActiveGameSession]),
   ],
-  providers: [AuthService],
+  providers: [AuthService, GameSessionService],
   exports: [AuthService],
   controllers: [AuthController],
 })

--- a/api/src/auth/game-session.entity.ts
+++ b/api/src/auth/game-session.entity.ts
@@ -1,0 +1,23 @@
+import { Column, Entity, Index, PrimaryColumn, UpdateDateColumn } from 'typeorm';
+
+@Entity({ name: 'active_game_sessions' })
+@Index('IDX_active_game_sessions_expires_at', ['expiresAt'])
+export class ActiveGameSession {
+  @PrimaryColumn({ type: 'integer', name: 'account_id' })
+  accountId: number;
+
+  @Column({ type: 'varchar', length: 64, name: 'lease_id' })
+  leaseId: string;
+
+  @Column({ type: 'varchar', length: 128, name: 'server_id' })
+  serverId: string;
+
+  @Column({ type: 'varchar', length: 128, name: 'owner_id' })
+  ownerId: string;
+
+  @Column({ type: 'timestamptz', name: 'expires_at' })
+  expiresAt: Date;
+
+  @UpdateDateColumn({ type: 'timestamptz', name: 'updated_at' })
+  updatedAt: Date;
+}

--- a/api/src/auth/game-session.service.spec.ts
+++ b/api/src/auth/game-session.service.spec.ts
@@ -1,0 +1,67 @@
+import { GameSessionService } from './game-session.service';
+
+describe('GameSessionService', () => {
+  let now: number;
+  let repository: any;
+  let service: GameSessionService;
+
+  beforeEach(() => {
+    now = Date.now();
+    jest.spyOn(Date, 'now').mockImplementation(() => now);
+    repository = {
+      query: jest.fn(),
+      findOne: jest.fn(),
+      update: jest.fn(),
+      delete: jest.fn(),
+    };
+    service = new GameSessionService(repository);
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('atomically acquires an expired or absent account lease', async () => {
+    repository.query.mockResolvedValue([{ lease_id: 'created' }]);
+
+    const result = await service.acquire(42, 'west/1', 'tab one');
+
+    expect(result.acquired).toBe(true);
+    expect(repository.query).toHaveBeenCalledTimes(1);
+    const params = repository.query.mock.calls[0][1];
+    expect(params[0]).toBe(42);
+    expect(params[2]).toBe('west1');
+    expect(params[3]).toBe('tabone');
+  });
+
+  it('rejects a competing live lease and reports its remaining lifetime', async () => {
+    repository.query.mockResolvedValue([]);
+    repository.findOne.mockResolvedValue({
+      accountId: 42,
+      expiresAt: new Date(now + 12_000),
+    });
+
+    const result = await service.acquire(42, 'west', 'other-tab');
+
+    expect(result).toEqual({ acquired: false, retryAfterMs: 12_000 });
+  });
+
+  it('heartbeats and releases only the matching lease owner', async () => {
+    repository.update.mockResolvedValue({ affected: 1 });
+    repository.delete.mockResolvedValue({ affected: 1 });
+
+    await expect(service.heartbeat(42, 'lease-a', 'west')).resolves.toBe(true);
+    await expect(service.release(42, 'lease-a', 'west')).resolves.toBe(true);
+
+    expect(repository.update.mock.calls[0][0]).toEqual({
+      accountId: 42,
+      leaseId: 'lease-a',
+      serverId: 'west',
+    });
+    expect(repository.delete.mock.calls[0][0]).toEqual({
+      accountId: 42,
+      leaseId: 'lease-a',
+      serverId: 'west',
+    });
+  });
+});

--- a/api/src/auth/game-session.service.ts
+++ b/api/src/auth/game-session.service.ts
@@ -1,0 +1,82 @@
+import { Injectable } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { v4 as uuidv4 } from 'uuid';
+import { ActiveGameSession } from './game-session.entity';
+
+export type GameSessionAcquireResult =
+  | { acquired: true; leaseId: string; expiresAt: Date; ttlMs: number }
+  | { acquired: false; retryAfterMs: number };
+
+@Injectable()
+export class GameSessionService {
+  static readonly leaseTtlMs = 45_000;
+
+  constructor(
+    @InjectRepository(ActiveGameSession)
+    private readonly sessions: Repository<ActiveGameSession>,
+  ) {}
+
+  private cleanId(value: unknown, fallback: string): string {
+    const cleaned = String(value || '')
+      .replace(/[^a-zA-Z0-9:._-]/g, '')
+      .slice(0, 128);
+    return cleaned || fallback;
+  }
+
+  async acquire(accountId: number, serverId: unknown, ownerId: unknown): Promise<GameSessionAcquireResult> {
+    const leaseId = uuidv4();
+    const safeServerId = this.cleanId(serverId, 'unknown-server');
+    const safeOwnerId = this.cleanId(ownerId, 'unknown-client');
+    const expiresAt = new Date(Date.now() + GameSessionService.leaseTtlMs);
+
+    // This conditional upsert is the lock. PostgreSQL serializes competing
+    // inserts for one account, so two game servers cannot both win.
+    const rows = await this.sessions.query(
+      `INSERT INTO active_game_sessions
+        (account_id, lease_id, server_id, owner_id, expires_at, updated_at)
+       VALUES ($1, $2, $3, $4, $5, NOW())
+       ON CONFLICT (account_id) DO UPDATE SET
+         lease_id = EXCLUDED.lease_id,
+         server_id = EXCLUDED.server_id,
+         owner_id = EXCLUDED.owner_id,
+         expires_at = EXCLUDED.expires_at,
+         updated_at = NOW()
+       WHERE active_game_sessions.expires_at <= NOW()
+       RETURNING lease_id, expires_at`,
+      [accountId, leaseId, safeServerId, safeOwnerId, expiresAt],
+    );
+
+    if (rows.length > 0) {
+      return { acquired: true, leaseId, expiresAt, ttlMs: GameSessionService.leaseTtlMs };
+    }
+
+    const active = await this.sessions.findOne({ where: { accountId } });
+    const retryAfterMs = active
+      ? Math.max(500, active.expiresAt.getTime() - Date.now())
+      : 1000;
+    return { acquired: false, retryAfterMs };
+  }
+
+  async heartbeat(accountId: number, leaseId: string, serverId: unknown): Promise<boolean> {
+    const expiresAt = new Date(Date.now() + GameSessionService.leaseTtlMs);
+    const result = await this.sessions.update(
+      {
+        accountId,
+        leaseId,
+        serverId: this.cleanId(serverId, 'unknown-server'),
+      },
+      { expiresAt },
+    );
+    return (result.affected || 0) === 1;
+  }
+
+  async release(accountId: number, leaseId: string, serverId: unknown): Promise<boolean> {
+    const result = await this.sessions.delete({
+      accountId,
+      leaseId,
+      serverId: this.cleanId(serverId, 'unknown-server'),
+    });
+    return (result.affected || 0) === 1;
+  }
+}

--- a/client/src/game/GameState.ts
+++ b/client/src/game/GameState.ts
@@ -16,6 +16,7 @@ import * as cosmetics from './cosmetics.json';
 import { perfMark, perfEnabled, perfWsProcess, perfEntityAdd } from './debug/perfStats';
 import { mark, span } from '../bootTiming';
 import { ldMark } from '../loaderDebug';
+import { browserPlayLease } from './network/BrowserPlayLease';
 const { skins } = cosmetics as any;
 
 const offscreenStaticTypes = new Set<number>([
@@ -169,9 +170,11 @@ class GameState {
     this.game.game.events.on('restartGame', this.restart, this);
     this.game.game.events.on('startSpectate', this.spectate, this);
     this.game.game.events.on('tokenUpdate', this.updateToken, this);
+    this.game.game.events.on('goHome', this.releaseBrowserPlayLease, this);
   }
 
   start(name: string) {
+    if (!this.acquireBrowserPlayLease()) return;
     let isFirstLife = false;
     try {
       if (!localStorage.getItem('swordbattle:hasPlayed')) {
@@ -198,6 +201,7 @@ class GameState {
   }
 
   restart() {
+    if (!this.acquireBrowserPlayLease()) return;
     const afterSent = () => {
       if(!this.game.hud.evolutionSelect.minimized) this.game.hud.evolutionSelect.toggleMinimize();
     }
@@ -233,6 +237,7 @@ class GameState {
   }
 
   onServerClose(event: CloseEvent, endpoint?: string) {
+    this.releaseBrowserPlayLease();
     // Closing without ever having opened means we never reached the box. Blacklist
     // it so the next getServer() picks elsewhere. Gating on "never opened" rather
     // than code 1006 matters: a healthy session that drops an hour in also closes
@@ -265,7 +270,7 @@ class GameState {
     }
 
     if (event.code === 4409) {
-      window.alert('Account is already in-game');
+      window.alert(event.reason || 'This account is already active in another game session.');
       return;
     }
 
@@ -293,7 +298,26 @@ class GameState {
     this.destroyed = true;
     this.payloadsQueue = [];
     this._pendingMessages = [];
+    this.releaseBrowserPlayLease();
     Socket.close();
+  }
+
+  private acquireBrowserPlayLease(): boolean {
+    if (!browserPlayLease) return true;
+    const acquired = browserPlayLease.acquire(() => {
+      const reason = 'Another Swordbattle tab took control of this browser session.';
+      window.alert(reason);
+      this.game.game.events.emit('connectionClosed', reason);
+      Socket.close();
+    });
+    if (!acquired) {
+      window.alert('Swordbattle is already being played in another tab. Close that game or return it to the menu first.');
+    }
+    return acquired;
+  }
+
+  private releaseBrowserPlayLease() {
+    browserPlayLease?.release();
   }
 
   onServerMessage(data: any) {

--- a/client/src/game/network/BrowserPlayLease.test.ts
+++ b/client/src/game/network/BrowserPlayLease.test.ts
@@ -1,0 +1,63 @@
+import { BrowserPlayLease } from './BrowserPlayLease';
+
+class MemoryStorage {
+  private values = new Map<string, string>();
+  getItem(key: string) { return this.values.get(key) ?? null; }
+  setItem(key: string, value: string) { this.values.set(key, value); }
+  removeItem(key: string) { this.values.delete(key); }
+}
+
+describe('BrowserPlayLease', () => {
+  let now = 1_000;
+  let storage: MemoryStorage;
+
+  beforeEach(() => {
+    jest.useFakeTimers();
+    now = 1_000;
+    storage = new MemoryStorage();
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  it('allows one playing tab and rejects a second live tab', () => {
+    const first = new BrowserPlayLease(storage as any, 'tab-a', () => now);
+    const second = new BrowserPlayLease(storage as any, 'tab-b', () => now);
+
+    expect(first.acquire()).toBe(true);
+    expect(second.acquire()).toBe(false);
+
+    first.release();
+    expect(second.acquire()).toBe(true);
+    second.release();
+  });
+
+  it('recovers automatically after a stale tab lease expires', () => {
+    const first = new BrowserPlayLease(storage as any, 'tab-a', () => now);
+    const second = new BrowserPlayLease(storage as any, 'tab-b', () => now);
+
+    expect(first.acquire()).toBe(true);
+    first.dispose();
+    // Simulate a crashed tab by restoring its stale record after dispose.
+    storage.setItem('swordbattle:active-play-session:v1', JSON.stringify({
+      ownerId: 'tab-a',
+      expiresAt: now + BrowserPlayLease.ttlMs,
+    }));
+    now += BrowserPlayLease.ttlMs + 1;
+
+    expect(second.acquire()).toBe(true);
+    second.release();
+  });
+
+  it('renews an owned lease while gameplay remains active', () => {
+    const lease = new BrowserPlayLease(storage as any, 'tab-a', () => now);
+    expect(lease.acquire()).toBe(true);
+    now += BrowserPlayLease.heartbeatMs;
+    jest.advanceTimersByTime(BrowserPlayLease.heartbeatMs);
+
+    const record = JSON.parse(storage.getItem('swordbattle:active-play-session:v1')!);
+    expect(record.expiresAt).toBe(now + BrowserPlayLease.ttlMs);
+    lease.release();
+  });
+});

--- a/client/src/game/network/BrowserPlayLease.ts
+++ b/client/src/game/network/BrowserPlayLease.ts
@@ -1,0 +1,137 @@
+type StorageLike = Pick<Storage, 'getItem' | 'setItem' | 'removeItem'>;
+
+type LeaseRecord = {
+  ownerId: string;
+  expiresAt: number;
+};
+
+const lockKey = 'swordbattle:active-play-session:v1';
+const tabIdKey = 'swordbattle:play-tab-id:v1';
+
+function createTabId(): string {
+  try {
+    const existing = window.sessionStorage.getItem(tabIdKey);
+    if (existing) return existing;
+    const id = window.crypto?.randomUUID?.()
+      || `${Date.now().toString(36)}-${Math.random().toString(36).slice(2)}`;
+    window.sessionStorage.setItem(tabIdKey, id);
+    return id;
+  } catch (_) {
+    return `${Date.now().toString(36)}-${Math.random().toString(36).slice(2)}`;
+  }
+}
+
+export class BrowserPlayLease {
+  static readonly ttlMs = 8_000;
+  static readonly heartbeatMs = 2_000;
+
+  private active = false;
+  private heartbeat: ReturnType<typeof setInterval> | null = null;
+  private onLost: (() => void) | null = null;
+  private readonly onStorageBound: (event: StorageEvent) => void;
+
+  constructor(
+    private readonly storage: StorageLike,
+    readonly ownerId: string,
+    private readonly now: () => number = () => Date.now(),
+    private readonly eventTarget?: EventTarget,
+  ) {
+    this.onStorageBound = this.handleStorage.bind(this);
+    this.eventTarget?.addEventListener('storage', this.onStorageBound as EventListener);
+  }
+
+  private read(): LeaseRecord | null {
+    try {
+      const raw = this.storage.getItem(lockKey);
+      if (!raw) return null;
+      const parsed = JSON.parse(raw);
+      if (typeof parsed?.ownerId !== 'string' || !Number.isFinite(parsed?.expiresAt)) return null;
+      return parsed;
+    } catch (_) {
+      return null;
+    }
+  }
+
+  private write(): boolean {
+    try {
+      this.storage.setItem(lockKey, JSON.stringify({
+        ownerId: this.ownerId,
+        expiresAt: this.now() + BrowserPlayLease.ttlMs,
+      }));
+      return this.read()?.ownerId === this.ownerId;
+    } catch (_) {
+      // Storage can be disabled. The server-side account lease remains the
+      // security boundary, so failing open here preserves playability.
+      return true;
+    }
+  }
+
+  acquire(onLost?: () => void): boolean {
+    this.onLost = onLost || null;
+    if (this.active) {
+      const current = this.read();
+      if (current && current.ownerId !== this.ownerId && current.expiresAt > this.now()) {
+        this.lose();
+        return false;
+      }
+      return this.write();
+    }
+
+    const existing = this.read();
+    if (existing && existing.ownerId !== this.ownerId && existing.expiresAt > this.now()) {
+      return false;
+    }
+    if (!this.write()) return false;
+
+    this.active = true;
+    this.heartbeat = setInterval(() => {
+      if (this.active && !this.write()) this.lose();
+    }, BrowserPlayLease.heartbeatMs);
+    return true;
+  }
+
+  release(): void {
+    if (this.read()?.ownerId === this.ownerId) {
+      try { this.storage.removeItem(lockKey); } catch (_) {}
+    }
+    this.deactivate();
+  }
+
+  isActive(): boolean {
+    return this.active;
+  }
+
+  dispose(): void {
+    this.release();
+    this.eventTarget?.removeEventListener('storage', this.onStorageBound as EventListener);
+  }
+
+  private handleStorage(event: StorageEvent): void {
+    if (!this.active || event.key !== lockKey) return;
+    const current = this.read();
+    if (current && current.ownerId !== this.ownerId && current.expiresAt > this.now()) {
+      this.lose();
+    }
+  }
+
+  private lose(): void {
+    const callback = this.onLost;
+    this.deactivate();
+    callback?.();
+  }
+
+  private deactivate(): void {
+    this.active = false;
+    this.onLost = null;
+    if (this.heartbeat) clearInterval(this.heartbeat);
+    this.heartbeat = null;
+  }
+}
+
+export const browserPlayLease = typeof window !== 'undefined'
+  ? new BrowserPlayLease(window.localStorage, createTabId(), () => Date.now(), window)
+  : null;
+
+if (typeof window !== 'undefined') {
+  window.addEventListener('pagehide', () => browserPlayLease?.release());
+}

--- a/client/src/game/network/Socket.ts
+++ b/client/src/game/network/Socket.ts
@@ -1,5 +1,6 @@
 import * as Protocol from './Protocol';
 import { registerIntegrityShutdown, registerIntegrityTarget } from '../integrity';
+import { browserPlayLease } from './BrowserPlayLease';
 
 const protocol = window.location.protocol === 'https:' ? 'wss://' : 'ws://';
 registerIntegrityTarget(WebSocket.prototype, ['close', 'send']);
@@ -70,8 +71,12 @@ class Socket {
   connect(address: string, onOpen: any, onMessage: any, onClose: any) {
     let authSecret = '';
     try { authSecret = window.localStorage.getItem('secret') || ''; } catch (e) {}
+    const query = new URLSearchParams();
+    if (authSecret) query.set('secret', authSecret);
+    if (browserPlayLease?.ownerId) query.set('sessionId', browserPlayLease.ownerId);
+    const queryString = query.toString();
     const sep = address.includes('?') ? '&' : '?';
-    const endpoint = `${protocol}${address}${authSecret ? `${sep}secret=${encodeURIComponent(authSecret)}` : ''}`;
+    const endpoint = `${protocol}${address}${queryString ? sep + queryString : ''}`;
     this.onMessage = onMessage;
 
     if (this.socket !== null) {

--- a/client/src/ui/App.tsx
+++ b/client/src/ui/App.tsx
@@ -42,6 +42,7 @@ import { getCookies, playVideoAd } from '../helpers';
 import Ad from './Ad';
 import { Settings } from '../game/Settings';
 import { getGameRuntime } from '../game/gameRuntime';
+import { browserPlayLease } from '../game/network/BrowserPlayLease';
 import { getServerList, updatePing } from '../ServerList';
 import AccountCard from './AccountCard';
 import ChangelogCard from './ChangelogCard';
@@ -981,6 +982,10 @@ function App({ profileDesigner = false, hudDesigner = false }: { profileDesigner
     localStorage.setItem('swordbattle:hasVisited', '1');
     if(!isConnected) {
       void showDialog('Still connecting to a server.', 'Connection');
+      return;
+    }
+    if (browserPlayLease && !browserPlayLease.acquire()) {
+      window.alert('Swordbattle is already being played in another tab. Close that game or return it to the menu first.');
       return;
     }
     else  {

--- a/server/src/game/Game.js
+++ b/server/src/game/Game.js
@@ -226,6 +226,15 @@ class Game {
 
     let { player } = client;
     if (data.play && (!player || player.removed)) {
+      if (client.account?.id && !client.hasGameSessionLease()) {
+        client.acquireGameSession((acquired) => {
+          if (acquired && !client.isSocketClosed) {
+            this.processClientMessage(client, data);
+          }
+        });
+        return;
+      }
+
       console.log('[CAPTCHA] Play request - recaptchaSecretKey:', !!config.recaptchaSecretKey, 'captchaVerified:', client.captchaVerified, 'hasCaptchaP1:', !!data.captchaP1, 'ip:', client.ip);
 
       if (getBannedIps().includes(client.ip)) {
@@ -630,6 +639,9 @@ class Game {
     if (!client.player) {
       spectator.initialize();
       client.fullSync = true;
+    }
+    if (!client.player || client.player.removed) {
+      client.releaseGameSession();
     }
     return spectator;
   }

--- a/server/src/network/Client.js
+++ b/server/src/network/Client.js
@@ -14,6 +14,7 @@ class Client {
     // this.ip = String.fromCharCode.apply(null, new Uint8Array(socket.getRemoteAddressAsText()));
 
     this.ip = socket.ip || String.fromCharCode.apply(null, new Uint8Array(socket.getRemoteAddressAsText()));
+    this.browserSessionId = socket.browserSessionId || this.id;
 
     console.log(`Client ${this.id} connected from ${this.ip} at ${Date.now()}`);
     this.token = '';
@@ -26,6 +27,14 @@ class Client {
     this.isReady = true;
     this.isSocketClosed = false;
     this.fullSync = true;
+    this.gameSessionLeaseId = '';
+    this.gameSessionExpiresAt = 0;
+    this.gameSessionNextHeartbeatAt = 0;
+    this.gameSessionHeartbeatPending = false;
+    this.gameSessionAcquirePending = false;
+    this.gameSessionAcquireCallbacks = [];
+    this.gameSessionGeneration = 0;
+    this.authGeneration = 0;
 
     this.messages = [];
     this.pingTimer = 0;
@@ -86,7 +95,9 @@ class Client {
       return;
     }
 
-    if(message.hasOwnProperty("token") && message.token === '' && this.token !== '' && this.account !== null) {
+    if(message.hasOwnProperty("token") && message.token === '' && this.token !== '') {
+      this.releaseGameSession();
+      this.authGeneration++;
       this.token = '';
       this.account = null;
     }
@@ -98,6 +109,8 @@ class Client {
       this.send({ isPong: true, tps: this.game.tps, realPlayersCnt });
     } else if (message.token) {
       // console.log('Client', this.id, 'authenticated with token');
+      if (message.token === this.token && this.account) return;
+      if (message.token !== this.token) this.releaseGameSession();
       this.token = message.token;
       this.getAccount();
     } else {
@@ -127,6 +140,8 @@ class Client {
     if (this.spectator) {
       this.spectator.update(dt);
     }
+
+    this.updateGameSessionLease();
 
     this.pingTimer -= 1;
     if (this.pingTimer <= 0) {
@@ -169,8 +184,11 @@ class Client {
     }
 
     this.isReady = false;
+    const token = this.token;
+    const generation = ++this.authGeneration;
     console.log('Client', this.id, 'authenticating with token POST /auth/verify');
-    api.post('/auth/verify', { secret: this.token }, (data) => {
+    api.post('/auth/verify', { secret: token }, (data) => {
+      if (generation !== this.authGeneration || token !== this.token || this.isSocketClosed) return;
       if (data && data.error) {
         console.warn(`Client ${this.id} authentication failed: ${data.message} (status: ${data.status || 'unknown'})`);
         this.token = '';
@@ -196,6 +214,109 @@ class Client {
       }
       this.isReady = true;
     });
+  }
+
+  hasGameSessionLease() {
+    return !!this.gameSessionLeaseId && this.gameSessionExpiresAt > Date.now();
+  }
+
+  acquireGameSession(callback = () => {}) {
+    if (!this.account?.id || !this.token) {
+      callback(true);
+      return;
+    }
+    if (this.hasGameSessionLease()) {
+      callback(true);
+      return;
+    }
+
+    this.gameSessionAcquireCallbacks.push(callback);
+    if (this.gameSessionAcquirePending) return;
+    this.gameSessionAcquirePending = true;
+    const generation = ++this.gameSessionGeneration;
+
+    api.post('/auth/game-session/acquire', {
+      secret: this.token,
+      serverId: this.server?.instanceId,
+      ownerId: this.browserSessionId,
+    }, (data) => {
+      if (generation !== this.gameSessionGeneration || this.isSocketClosed) return;
+
+      this.gameSessionAcquirePending = false;
+      const callbacks = this.gameSessionAcquireCallbacks;
+      this.gameSessionAcquireCallbacks = [];
+
+      if (data?.acquired && data.leaseId) {
+        this.gameSessionLeaseId = data.leaseId;
+        const ttlMs = Number(data.ttlMs) || Client.gameSessionTtlMs;
+        this.gameSessionExpiresAt = Date.now() + ttlMs;
+        this.gameSessionNextHeartbeatAt = Date.now() + Client.gameSessionHeartbeatMs;
+        callbacks.forEach((done) => done(true));
+        return;
+      }
+
+      callbacks.forEach((done) => done(false));
+      if (data?.status === 409 || data?.code === 'GAME_SESSION_ACTIVE') {
+        try { this.socket.end(4409, 'Account is already active in another game session'); } catch (e) {}
+      } else {
+        console.warn('[SESSION] Failed to acquire gameplay lease:', data?.message || data);
+        try { this.socket.end(1013, 'Session service temporarily unavailable'); } catch (e) {}
+      }
+    });
+  }
+
+  updateGameSessionLease() {
+    if (!this.gameSessionLeaseId || !this.account?.id || this.gameSessionHeartbeatPending) return;
+    const now = Date.now();
+    if (now < this.gameSessionNextHeartbeatAt) return;
+
+    const leaseId = this.gameSessionLeaseId;
+    this.gameSessionHeartbeatPending = true;
+    this.gameSessionNextHeartbeatAt = now + Client.gameSessionHeartbeatMs;
+    api.post('/auth/game-session/heartbeat', {
+      accountId: this.account.id,
+      leaseId,
+      serverId: this.server?.instanceId,
+    }, (data) => {
+      if (leaseId !== this.gameSessionLeaseId) return;
+      this.gameSessionHeartbeatPending = false;
+
+      if (data?.active) {
+        this.gameSessionExpiresAt = Date.now() + (Number(data.ttlMs) || Client.gameSessionTtlMs);
+        return;
+      }
+
+      if (data?.error && Date.now() < this.gameSessionExpiresAt) {
+        this.gameSessionNextHeartbeatAt = Date.now() + Client.gameSessionRetryMs;
+        return;
+      }
+
+      this.gameSessionLeaseId = '';
+      const code = data?.error ? 1013 : 4409;
+      const reason = data?.error
+        ? 'Session service temporarily unavailable'
+        : 'Gameplay session was replaced';
+      try { this.socket.end(code, reason); } catch (e) {}
+    });
+  }
+
+  releaseGameSession() {
+    const leaseId = this.gameSessionLeaseId;
+    const accountId = this.account?.id;
+    const serverId = this.server?.instanceId;
+
+    this.gameSessionGeneration++;
+    this.gameSessionLeaseId = '';
+    this.gameSessionExpiresAt = 0;
+    this.gameSessionNextHeartbeatAt = 0;
+    this.gameSessionHeartbeatPending = false;
+    this.gameSessionAcquirePending = false;
+    const callbacks = this.gameSessionAcquireCallbacks;
+    this.gameSessionAcquireCallbacks = [];
+    callbacks.forEach((done) => done(false));
+
+    if (!leaseId || !accountId) return;
+    api.post('/auth/game-session/release', { accountId, leaseId, serverId });
   }
 
   getAccountAsync() {
@@ -267,5 +388,8 @@ class Client {
 
 Client.pingIntervalTicks = 200;
 Client.pongTimeoutMs = 45000;
+Client.gameSessionHeartbeatMs = 15000;
+Client.gameSessionRetryMs = 5000;
+Client.gameSessionTtlMs = 45000;
 
 module.exports = Client;

--- a/server/src/network/Server.js
+++ b/server/src/network/Server.js
@@ -12,6 +12,7 @@ class Server {
     this.clients = new Map();
     this.disconnectedClients = new Set();
     this.maxConnectionsPerIP = 50;
+    this.instanceId = process.env.SERVER_INSTANCE_ID || uuidv4();
 
     // Maintenance mode
     this.maintenanceMode = false;
@@ -53,6 +54,11 @@ class Server {
         const forwardedFor = req.getHeader('x-forwarded-for') || req.getHeader('cf-connecting-ip') || '';
         const ips = forwardedFor.split(',').map(i => i.trim());
         const ip = ips[0];
+        let browserSessionId = '';
+        try {
+          browserSessionId = new URLSearchParams(req.getQuery() || '').get('sessionId') || '';
+        } catch (e) {}
+        browserSessionId = browserSessionId.replace(/[^a-zA-Z0-9:._-]/g, '').slice(0, 128);
         if (this.maintenanceMode) {
           let secret = '';
           try { secret = new URLSearchParams(req.getQuery() || '').get('secret') || ''; } catch (e) { secret = ''; }
@@ -76,7 +82,7 @@ class Server {
           .filter(client => client.ip === ip).length;
 
         if (currentConnections >= this.maxConnectionsPerIP) {
-          res.upgrade({ id: uuidv4(), ip, tooManyConnections: true },
+          res.upgrade({ id: uuidv4(), ip, browserSessionId, tooManyConnections: true },
             req.getHeader('sec-websocket-key'),
             req.getHeader('sec-websocket-protocol'),
             req.getHeader('sec-websocket-extensions'), context,
@@ -92,7 +98,7 @@ class Server {
           return;
         }
 
-        res.upgrade({ id: uuidv4(), ip },
+        res.upgrade({ id: uuidv4(), ip, browserSessionId },
           req.getHeader('sec-websocket-key'),
           req.getHeader('sec-websocket-protocol'),
           req.getHeader('sec-websocket-extensions'), context,
@@ -139,6 +145,7 @@ class Server {
         const client = this.clients.get(socket.id);
         if (!client) return;
         client.isSocketClosed = true;
+        client.releaseGameSession();
         try {
           if (client.player && !client.player.removed) {
             client.player.remove();

--- a/server/src/network/api.js
+++ b/server/src/network/api.js
@@ -17,7 +17,12 @@ function get(path, callback = (data) => {}) {
   .then(async res => {
     if (!res.ok) {
       const text = await res.text();
-      return { error: true, status: res.status, message: text };
+      try {
+        const parsed = JSON.parse(text);
+        return { ...parsed, error: true, status: res.status, message: parsed.message || text };
+      } catch (e) {
+        return { error: true, status: res.status, message: text };
+      }
     }
     const contentType = res.headers.get('content-type');
     if (contentType && contentType.includes('application/json')) {
@@ -46,7 +51,12 @@ function post(path, body, callback = (data) => {}) {
   .then(async res => {
     if (!res.ok) {
       const text = await res.text();
-      return { error: true, status: res.status, message: text };
+      try {
+        const parsed = JSON.parse(text);
+        return { ...parsed, error: true, status: res.status, message: parsed.message || text };
+      } catch (e) {
+        return { error: true, status: res.status, message: text };
+      }
     }
     const contentType = res.headers.get('content-type');
     if (contentType && contentType.includes('application/json')) {


### PR DESCRIPTION
Adds server-authoritative gameplay leases that permit only one live game per signed-in account across servers, with atomic acquisition, heartbeats, stale-session recovery, and lifecycle cleanup on disconnect, logout, account changes, and returning home. It also adds a browser-scoped play lease that blocks simultaneous gameplay across tabs—even when different accounts are used in the same browser—before the UI enters gameplay, while leaving spectating unrestricted and showing clear duplicate-session messages. The API and client production builds pass, along with focused gameplay-session and browser-lease tests (3/3 each).